### PR TITLE
Add Prometheus metrics + Grafana Cloud integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2283,6 +2283,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "procfs"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "731e0d9356b0c25f16f33b5be79b1c57b562f141ebfcdb0ad8ac2c13a24293b4"
+dependencies = [
+ "bitflags 2.10.0",
+ "hex",
+ "lazy_static",
+ "procfs-core",
+ "rustix 0.38.44",
+]
+
+[[package]]
+name = "procfs-core"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d3554923a69f4ce04c4a754260c338f505ce22642d3830e049a399fc2059a29"
+dependencies = [
+ "bitflags 2.10.0",
+ "hex",
+]
+
+[[package]]
 name = "prometheus"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2291,8 +2314,10 @@ dependencies = [
  "cfg-if",
  "fnv",
  "lazy_static",
+ "libc",
  "memchr",
  "parking_lot 0.12.5",
+ "procfs",
  "protobuf",
  "thiserror 1.0.69",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ async-trait = "0.1.60"
 async-std = "1.12.0"
 sqlx = { version ="0.6.2", features=["runtime-tokio-rustls", "postgres", "chrono"]}
 chrono = "0.4.23"
-prometheus = "0.13.3"
+prometheus = { version = "0.13.3", features = ["process"] }
 indicatif = "0.17.3"
 bech32 = "0.9.1"
 url = "2.3.1"

--- a/alloy/config.alloy
+++ b/alloy/config.alloy
@@ -8,16 +8,6 @@ prometheus.scrape "relay" {
   scrape_interval = "15s"
 }
 
-// Scrape cAdvisor for per-container CPU / memory / network / disk I/O.
-prometheus.scrape "cadvisor" {
-  targets = [{
-    __address__ = "cadvisor:8080",
-    job         = "cadvisor",
-  }]
-  forward_to      = [prometheus.remote_write.grafana_cloud.receiver]
-  scrape_interval = "15s"
-}
-
 // Forward all scraped series to Grafana Cloud.
 prometheus.remote_write "grafana_cloud" {
   endpoint {

--- a/alloy/config.alloy
+++ b/alloy/config.alloy
@@ -1,0 +1,31 @@
+// Scrape the relay's /metrics endpoint (Nostr-level + process_* on Linux).
+prometheus.scrape "relay" {
+  targets = [{
+    __address__ = "relay:8080",
+    job         = "nostr-rs-relay",
+  }]
+  forward_to      = [prometheus.remote_write.grafana_cloud.receiver]
+  scrape_interval = "15s"
+}
+
+// Scrape cAdvisor for per-container CPU / memory / network / disk I/O.
+prometheus.scrape "cadvisor" {
+  targets = [{
+    __address__ = "cadvisor:8080",
+    job         = "cadvisor",
+  }]
+  forward_to      = [prometheus.remote_write.grafana_cloud.receiver]
+  scrape_interval = "15s"
+}
+
+// Forward all scraped series to Grafana Cloud.
+prometheus.remote_write "grafana_cloud" {
+  endpoint {
+    url = sys.env("GRAFANA_REMOTE_WRITE_URL")
+
+    basic_auth {
+      username = sys.env("GRAFANA_USERNAME")
+      password = sys.env("GRAFANA_API_TOKEN")
+    }
+  }
+}

--- a/docker-compose.metrics.yml
+++ b/docker-compose.metrics.yml
@@ -38,7 +38,9 @@ services:
       - --docker_only=true
 
   alloy:
-    image: grafana/alloy:latest
+    # pin the Alloy version explicitly so this stack stays reproducible.
+    # bump deliberately when needed; do not switch to :latest.
+    image: grafana/alloy:v1.16.0
     command:
       - run
       - /etc/alloy/config.alloy

--- a/docker-compose.metrics.yml
+++ b/docker-compose.metrics.yml
@@ -1,5 +1,5 @@
 # Local stack for verifying the metrics pipeline end-to-end:
-# relay -> cAdvisor (container metrics) -> Alloy -> Grafana Cloud
+#   relay -> Alloy -> Grafana Cloud
 #
 # Required env vars (set in .env or shell):
 #   GRAFANA_REMOTE_WRITE_URL  - Prometheus remote_write endpoint
@@ -9,10 +9,11 @@
 # Usage:
 #   docker compose -f docker-compose.metrics.yml up
 #
-# In production (ECS) the relay and Alloy run as separate task definitions and
-# cAdvisor is replaced by the ECS task-level CloudWatch metrics or an Alloy
-# component scraping the ECS metadata endpoint. RDS host metrics come from
-# CloudWatch (see docs/metrics.md).
+# In production this relay runs on AWS Fargate. Container-level CPU / memory /
+# network metrics come from ECS/Fargate's built-in CloudWatch Container
+# Insights, not from cAdvisor (which can't run in Fargate — no access to
+# /sys, /var/lib/docker, or /dev/kmsg). RDS host metrics also come from
+# CloudWatch. See docs/metrics.md for the CloudWatch -> Grafana Cloud path.
 
 services:
   relay:
@@ -22,20 +23,6 @@ services:
     volumes:
       - ./config.toml:/usr/src/app/config.toml:ro
       - ./data:/usr/src/app/db
-
-  cadvisor:
-    image: gcr.io/cadvisor/cadvisor:v0.49.1
-    privileged: true
-    devices:
-      - /dev/kmsg
-    volumes:
-      - /:/rootfs:ro
-      - /var/run:/var/run:ro
-      - /sys:/sys:ro
-      - /var/lib/docker/:/var/lib/docker:ro
-    command:
-      - --housekeeping_interval=15s
-      - --docker_only=true
 
   alloy:
     # pin the Alloy version explicitly so this stack stays reproducible.
@@ -55,4 +42,3 @@ services:
       - GRAFANA_API_TOKEN
     depends_on:
       - relay
-      - cadvisor

--- a/docker-compose.metrics.yml
+++ b/docker-compose.metrics.yml
@@ -1,0 +1,56 @@
+# Local stack for verifying the metrics pipeline end-to-end:
+# relay -> cAdvisor (container metrics) -> Alloy -> Grafana Cloud
+#
+# Required env vars (set in .env or shell):
+#   GRAFANA_REMOTE_WRITE_URL  - Prometheus remote_write endpoint
+#   GRAFANA_USERNAME          - instance ID / numeric username
+#   GRAFANA_API_TOKEN         - API token with metrics:write scope
+#
+# Usage:
+#   docker compose -f docker-compose.metrics.yml up
+#
+# In production (ECS) the relay and Alloy run as separate task definitions and
+# cAdvisor is replaced by the ECS task-level CloudWatch metrics or an Alloy
+# component scraping the ECS metadata endpoint. RDS host metrics come from
+# CloudWatch (see docs/metrics.md).
+
+services:
+  relay:
+    build: .
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./config.toml:/usr/src/app/config.toml:ro
+      - ./data:/usr/src/app/db
+
+  cadvisor:
+    image: gcr.io/cadvisor/cadvisor:v0.49.1
+    privileged: true
+    devices:
+      - /dev/kmsg
+    volumes:
+      - /:/rootfs:ro
+      - /var/run:/var/run:ro
+      - /sys:/sys:ro
+      - /var/lib/docker/:/var/lib/docker:ro
+    command:
+      - --housekeeping_interval=15s
+      - --docker_only=true
+
+  alloy:
+    image: grafana/alloy:latest
+    command:
+      - run
+      - /etc/alloy/config.alloy
+      - --server.http.listen-addr=0.0.0.0:12345
+    ports:
+      - "12345:12345"
+    volumes:
+      - ./alloy/config.alloy:/etc/alloy/config.alloy:ro
+    environment:
+      - GRAFANA_REMOTE_WRITE_URL
+      - GRAFANA_USERNAME
+      - GRAFANA_API_TOKEN
+    depends_on:
+      - relay
+      - cadvisor

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -91,7 +91,7 @@ These are sourced from `procfs` and only present on Linux. macOS dev builds will
 
 The relay does not expose machine-level CPU / RAM / disk / network — those come from sidecars:
 
-- **Container metrics** (Docker / ECS) — bundle the [`cadvisor`](https://github.com/google/cadvisor) sidecar in `docker-compose.metrics.yml`. Alloy scrapes it alongside the relay; no app changes needed. Series include `container_cpu_usage_seconds_total`, `container_memory_rss`, `container_network_*_bytes_total`, `container_fs_writes_total`, etc.
+- **Container metrics** (Fargate) — use [ECS/Fargate Container Insights](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Container-Insights.html). Enable it on the cluster and AWS publishes per-task and per-container CPU / memory / network / storage metrics into the `ECS/ContainerInsights` CloudWatch namespace. Cross-import to Grafana via the same CloudWatch integration as RDS (see below). cAdvisor is *not* an option in Fargate — the runtime hides `/sys`, `/var/lib/docker`, and `/dev/kmsg`, all of which cAdvisor needs to read.
 - **Bare-host metrics** (non-containerized VMs) — use `node_exporter` instead. Not bundled here; add it as another scrape target in `alloy/config.alloy` if needed.
 - **RDS database host metrics** — RDS does not allow installing exporters. Use one of:
   - **CloudWatch → Grafana Cloud**: enable the [Grafana Cloud AWS integration](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/aws/cloudwatch/) to pull RDS namespace metrics (`AWS/RDS`: CPUUtilization, FreeableMemory, DatabaseConnections, FreeStorageSpace, ReadIOPS / WriteIOPS, etc.).

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -38,9 +38,9 @@ Counters for raw command frames received from clients.
 
 | Metric | Type | Labels | Description |
 |---|---|---|---|
-| `nostr_events_received_by_kind_total` | counter | `kind` | Valid events received from clients, broken down by Nostr kind |
-| `nostr_events_persisted_by_kind_total` | counter | `kind` | Events successfully persisted (or broadcast for ephemeral kinds), by kind |
-| `nostr_events_rejected_total` | counter | `reason` | Events rejected before persistence. Reasons: `kind_blacklist`, `kind_allowlist`, `pubkey_not_whitelisted`, `nip05_invalid`, `nip05_missing`, `nip05_error`, `grpc_denied`, `duplicate`, `write_error` |
+| `nostr_events_received_by_kind_total` | counter | `kind` | Successfully parsed events received from clients, by kind. Includes events that get rejected downstream — every increment here should match either an `events_persisted_by_kind` or an `events_rejected` increment. |
+| `nostr_events_persisted_by_kind_total` | counter | `kind` | Events successfully written to the database, by kind. Ephemeral events are *not* counted here — they are broadcast but not persisted. |
+| `nostr_events_rejected_total` | counter | `reason` | Events rejected before persistence. Reasons: `expired`, `future_dated`, `kind_blacklist`, `kind_allowlist`, `pubkey_not_whitelisted`, `not_admitted`, `insufficient_balance`, `pubkey_not_registered`, `admission_check_error`, `nip05_invalid`, `nip05_missing`, `nip05_error`, `grpc_denied`, `duplicate`, `write_error` |
 | `nostr_events_sent_total` | counter | `source` | Events sent to subscribers. `source` = `db` (historical query result) or `realtime` (broadcast match) |
 
 ### Latency histograms
@@ -55,7 +55,12 @@ Default Prometheus buckets (`5ms` … `10s`).
 
 ## State metrics (background-collected)
 
-A tokio task in `start_server` polls the database every 30 s (first pass 5 s after boot) and updates these gauges via `NostrRepo` trait methods. On Postgres, queries are designed to avoid sequential scans — `pg_class.reltuples` for the total estimate, `pg_stats.n_distinct` for distinct authors, `pg_database_size` for size. On SQLite they are direct counts.
+A tokio task in `start_server` polls the database on two cadences:
+
+- **Fast (every 30 s, first pass 5 s after boot)**: total events, distinct authors, DB size. On Postgres these are cheap planner-stat reads (`pg_class.reltuples`, `pg_stats.n_distinct`, `pg_database_size`); on SQLite they are direct counts.
+- **Slow (every 10 min, first pass 15 s after boot)**: per-kind event counts. The query is a `GROUP BY kind` which is a sequential scan on Postgres; running it less often keeps the buffer cache from being thrashed. The collector updates labels in-place and only removes labels for kinds that disappeared between cycles, so dashboards don't see scrape gaps.
+
+If `pg_stats` has no row for `event.pub_key` (typical right after a fresh load before `ANALYZE` has run, or if the connecting role lacks `SELECT` on the table) the distinct-authors gauge reads 0. The relay logs a one-shot warning so the operator sees the cause.
 
 | Metric | Type | Labels | Description |
 |---|---|---|---|

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -67,7 +67,7 @@ If `pg_stats` has no row for `event.pub_key` (typical right after a fresh load b
 | `nostr_db_events_total` | gauge | — | Estimated total event rows |
 | `nostr_db_events_by_kind` | gauge | `kind` | Event count per Nostr kind in the database |
 | `nostr_db_authors_distinct` | gauge | — | Distinct authors (estimate on Postgres, exact on SQLite) |
-| `nostr_db_size_bytes` | gauge | — | Database size on disk |
+| `nostr_db_size_bytes` | gauge | — | Database size. On Postgres this is `pg_database_size(current_database())`. On SQLite it is `page_count * page_size` of the **main DB file only** — the `-wal` and `-shm` sidecars (which can be substantial in WAL mode) are not included. Production runs Postgres, where this is exact. |
 | `nostr_db_connections` | gauge | — | Active DB connections in use |
 
 ## Process metrics (relay process: CPU, RSS, FDs)

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -38,8 +38,9 @@ Counters for raw command frames received from clients.
 
 | Metric | Type | Labels | Description |
 |---|---|---|---|
-| `nostr_events_received_by_kind_total` | counter | `kind` | Successfully parsed events received from clients, by kind. Includes events that get rejected downstream — every increment here should match either an `events_persisted_by_kind` or an `events_rejected` increment. |
-| `nostr_events_persisted_by_kind_total` | counter | `kind` | Events successfully written to the database, by kind. Ephemeral events are *not* counted here — they are broadcast but not persisted. |
+| `nostr_events_received_by_kind_total` | counter | `kind` | Successfully parsed events received from clients, by kind. The accounting identity `received = persisted + ephemeral_broadcast + rejected` holds across all kinds (see the three counters below). |
+| `nostr_events_persisted_by_kind_total` | counter | `kind` | Events successfully written to the database, by kind. Ephemeral events (kinds in `[20000, 30000)`) are *not* counted here — see the next row. |
+| `nostr_events_ephemeral_broadcast_by_kind_total` | counter | `kind` | Ephemeral events broadcast to subscribers without being persisted, by kind. |
 | `nostr_events_rejected_total` | counter | `reason` | Events rejected before persistence. Reasons: `expired`, `future_dated`, `kind_blacklist`, `kind_allowlist`, `pubkey_not_whitelisted`, `not_admitted`, `insufficient_balance`, `pubkey_not_registered`, `admission_check_error`, `nip05_invalid`, `nip05_missing`, `nip05_error`, `grpc_denied`, `duplicate`, `write_error` |
 | `nostr_events_sent_total` | counter | `source` | Events sent to subscribers. `source` = `db` (historical query result) or `realtime` (broadcast match) |
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,0 +1,116 @@
+# Metrics
+
+The relay exposes Prometheus-format metrics at `GET /metrics` on the same port as the WebSocket. The endpoint is unauthenticated — scope it via your reverse proxy / network ACL when running in production.
+
+All metric series are defined in `src/server.rs::create_metrics`.
+
+## Hot-path metrics (event-driven)
+
+These are updated synchronously as traffic hits the relay.
+
+### Connection lifecycle
+
+| Metric | Type | Labels | Description |
+|---|---|---|---|
+| `nostr_connections_total` | counter | — | New WebSocket connections accepted (cumulative) |
+| `nostr_connections_active` | gauge | — | Currently-open WebSocket connections |
+| `nostr_disconnects_total` | counter | `reason` | Disconnects, by cause: `shutdown`, `timeout`, `send_error`, `normal`, `error` |
+
+### Subscription lifecycle
+
+| Metric | Type | Labels | Description |
+|---|---|---|---|
+| `nostr_subscriptions_active` | gauge | — | Currently-active REQ subscriptions across all clients |
+| `nostr_query_abort_total` | counter | `reason` | Server-side query aborts |
+
+### Protocol commands
+
+Counters for raw command frames received from clients.
+
+| Metric | Type | Labels | Description |
+|---|---|---|---|
+| `nostr_cmd_req_total` | counter | — | `REQ` (subscribe) commands |
+| `nostr_cmd_event_total` | counter | — | `EVENT` (publish) commands |
+| `nostr_cmd_close_total` | counter | — | `CLOSE` (unsubscribe) commands |
+| `nostr_cmd_auth_total` | counter | — | `AUTH` (NIP-42) commands |
+
+### Event flow
+
+| Metric | Type | Labels | Description |
+|---|---|---|---|
+| `nostr_events_received_by_kind_total` | counter | `kind` | Valid events received from clients, broken down by Nostr kind |
+| `nostr_events_persisted_by_kind_total` | counter | `kind` | Events successfully persisted (or broadcast for ephemeral kinds), by kind |
+| `nostr_events_rejected_total` | counter | `reason` | Events rejected before persistence. Reasons: `kind_blacklist`, `kind_allowlist`, `pubkey_not_whitelisted`, `nip05_invalid`, `nip05_missing`, `nip05_error`, `grpc_denied`, `duplicate`, `write_error` |
+| `nostr_events_sent_total` | counter | `source` | Events sent to subscribers. `source` = `db` (historical query result) or `realtime` (broadcast match) |
+
+### Latency histograms
+
+Default Prometheus buckets (`5ms` … `10s`).
+
+| Metric | Type | Description |
+|---|---|---|
+| `nostr_query_seconds` | histogram | End-to-end subscription response time |
+| `nostr_filter_seconds` | histogram | Single SQL filter execution time |
+| `nostr_events_write_seconds` | histogram | Event-write latency |
+
+## State metrics (background-collected)
+
+A tokio task in `start_server` polls the database every 30 s (first pass 5 s after boot) and updates these gauges via `NostrRepo` trait methods. On Postgres, queries are designed to avoid sequential scans — `pg_class.reltuples` for the total estimate, `pg_stats.n_distinct` for distinct authors, `pg_database_size` for size. On SQLite they are direct counts.
+
+| Metric | Type | Labels | Description |
+|---|---|---|---|
+| `nostr_db_events_total` | gauge | — | Estimated total event rows |
+| `nostr_db_events_by_kind` | gauge | `kind` | Event count per Nostr kind in the database |
+| `nostr_db_authors_distinct` | gauge | — | Distinct authors (estimate on Postgres, exact on SQLite) |
+| `nostr_db_size_bytes` | gauge | — | Database size on disk |
+| `nostr_db_connections` | gauge | — | Active DB connections in use |
+
+## Process metrics (relay process: CPU, RSS, FDs)
+
+When built on Linux, the relay registers `prometheus::process_collector::ProcessCollector::for_self()` so `/metrics` also includes:
+
+| Metric | Type | Description |
+|---|---|---|
+| `process_cpu_seconds_total` | counter | Total CPU time consumed by the relay process |
+| `process_resident_memory_bytes` | gauge | Resident set size |
+| `process_virtual_memory_bytes` | gauge | Virtual memory size |
+| `process_open_fds` | gauge | Open file descriptors |
+| `process_max_fds` | gauge | File descriptor limit |
+| `process_threads` | gauge | OS threads |
+| `process_start_time_seconds` | gauge | Unix-time start of the process |
+
+These are sourced from `procfs` and only present on Linux. macOS dev builds will not show `process_*` series — the Docker/ECS deployment will.
+
+## Host / container / DB metrics (out-of-process)
+
+The relay does not expose machine-level CPU / RAM / disk / network — those come from sidecars:
+
+- **Container metrics** (Docker / ECS) — bundle the [`cadvisor`](https://github.com/google/cadvisor) sidecar in `docker-compose.metrics.yml`. Alloy scrapes it alongside the relay; no app changes needed. Series include `container_cpu_usage_seconds_total`, `container_memory_rss`, `container_network_*_bytes_total`, `container_fs_writes_total`, etc.
+- **Bare-host metrics** (non-containerized VMs) — use `node_exporter` instead. Not bundled here; add it as another scrape target in `alloy/config.alloy` if needed.
+- **RDS database host metrics** — RDS does not allow installing exporters. Use one of:
+  - **CloudWatch → Grafana Cloud**: enable the [Grafana Cloud AWS integration](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/aws/cloudwatch/) to pull RDS namespace metrics (`AWS/RDS`: CPUUtilization, FreeableMemory, DatabaseConnections, FreeStorageSpace, ReadIOPS / WriteIOPS, etc.).
+  - **`cloudwatch_exporter`**: self-hosted Prometheus exporter that reads the same data; useful if you don't run Grafana Cloud.
+
+  These are independent of this repo and configured at the AWS / Grafana account level.
+
+The relay's own `nostr_db_size_bytes` gauge gives the **logical** Postgres database size (`pg_database_size`); CloudWatch's `FreeStorageSpace` gives the underlying RDS volume free space.
+
+## Notes on label cardinality
+
+`kind` is the Nostr event kind as decimal string. In typical operation the relay sees a small bounded set of kinds (single-digit count for a focused relay; a few dozen for a general-purpose one). If unbounded "kind spam" becomes a concern, consider gating with `limits.event_kind_allowlist` in `config.toml` — that simultaneously enforces policy and bounds metric cardinality.
+
+`reason` labels are all enumerated above and bounded.
+
+## Scraping
+
+Direct Prometheus scrape:
+
+```yaml
+scrape_configs:
+  - job_name: nostr-rs-relay
+    static_configs:
+      - targets: ['relay:8080']
+    scrape_interval: 15s
+```
+
+Grafana Alloy → Grafana Cloud is wired up via `docker-compose.metrics.yml` and `alloy/config.alloy`. Required env vars: `GRAFANA_REMOTE_WRITE_URL`, `GRAFANA_USERNAME`, `GRAFANA_API_TOKEN`.

--- a/src/db.rs
+++ b/src/db.rs
@@ -99,6 +99,7 @@ async fn build_postgres_pool(settings: &Settings, metrics: NostrMetrics) -> Post
 }
 
 /// Spawn a database writer that persists events to the `SQLite` store.
+#[allow(clippy::too_many_arguments)]
 pub async fn db_writer(
     repo: Arc<dyn NostrRepo>,
     settings: Settings,
@@ -107,6 +108,7 @@ pub async fn db_writer(
     metadata_tx: tokio::sync::broadcast::Sender<Event>,
     payment_tx: tokio::sync::broadcast::Sender<PaymentMessage>,
     mut shutdown: tokio::sync::broadcast::Receiver<()>,
+    metrics: NostrMetrics,
 ) -> Result<()> {
     // are we performing NIP-05 checking?
     let nip05_active = settings.verified_users.is_active();
@@ -176,6 +178,10 @@ pub async fn db_writer(
                 notice_tx
                     .try_send(Notice::blocked(event.id, "event kind is blocked by relay"))
                     .ok();
+                metrics
+                    .events_rejected
+                    .with_label_values(&["kind_blacklist"])
+                    .inc();
                 continue;
             }
         }
@@ -192,6 +198,10 @@ pub async fn db_writer(
                 notice_tx
                     .try_send(Notice::blocked(event.id, "event kind is blocked by relay"))
                     .ok();
+                metrics
+                    .events_rejected
+                    .with_label_values(&["kind_allowlist"])
+                    .inc();
                 continue;
             }
         }
@@ -217,6 +227,10 @@ pub async fn db_writer(
                             "pubkey is not allowed to publish to this relay",
                         ))
                         .ok();
+                    metrics
+                        .events_rejected
+                        .with_label_values(&["pubkey_not_whitelisted"])
+                        .inc();
                     continue;
                 }
             }
@@ -310,6 +324,10 @@ pub async fn db_writer(
                                 "NIP-05 verification is no longer valid (expired/wrong domain)",
                             ))
                             .ok();
+                        metrics
+                            .events_rejected
+                            .with_label_values(&["nip05_invalid"])
+                            .inc();
                         continue;
                     }
                 }
@@ -327,10 +345,18 @@ pub async fn db_writer(
                             "NIP-05 verification needed to publish events",
                         ))
                         .ok();
+                    metrics
+                        .events_rejected
+                        .with_label_values(&["nip05_missing"])
+                        .inc();
                     continue;
                 }
                 Err(e) => {
                     warn!("checking nip05 verification status failed: {:?}", e);
+                    metrics
+                        .events_rejected
+                        .with_label_values(&["nip05_error"])
+                        .inc();
                     continue;
                 }
             }
@@ -372,6 +398,10 @@ pub async fn db_writer(
                                 &decision.message().unwrap_or_default(),
                             ))
                             .ok();
+                        metrics
+                            .events_rejected
+                            .with_label_values(&["grpc_denied"])
+                            .inc();
                         continue;
                     }
                 }
@@ -401,6 +431,10 @@ pub async fn db_writer(
                 start.elapsed()
             );
             event_write = true;
+            metrics
+                .events_persisted_by_kind
+                .with_label_values(&[&event.kind.to_string()])
+                .inc();
 
             // send OK message
             notice_tx.try_send(Notice::saved(event.id)).ok();
@@ -410,6 +444,10 @@ pub async fn db_writer(
                     if updated == 0 {
                         trace!("ignoring duplicate or deleted event");
                         notice_tx.try_send(Notice::duplicate(event.id)).ok();
+                        metrics
+                            .events_rejected
+                            .with_label_values(&["duplicate"])
+                            .inc();
                     } else {
                         info!(
                             "persisted event: {:?} (kind: {}) from: {:?} in: {:?} (IP: {:?})",
@@ -420,6 +458,10 @@ pub async fn db_writer(
                             subm_event.source_ip,
                         );
                         event_write = true;
+                        metrics
+                            .events_persisted_by_kind
+                            .with_label_values(&[&event.kind.to_string()])
+                            .inc();
                         // send this out to all clients
                         bcast_tx.send(event.clone()).ok();
                         notice_tx.try_send(Notice::saved(event.id)).ok();
@@ -429,6 +471,10 @@ pub async fn db_writer(
                     warn!("event insert failed: {:?}", err);
                     let msg = "relay experienced an error trying to publish the latest event";
                     notice_tx.try_send(Notice::error(event.id, msg)).ok();
+                    metrics
+                        .events_rejected
+                        .with_label_values(&["write_error"])
+                        .inc();
                 }
             }
         }

--- a/src/db.rs
+++ b/src/db.rs
@@ -112,7 +112,10 @@ pub struct DbWriterContext {
     pub metrics: NostrMetrics,
 }
 
-/// Spawn a database writer that persists events to the `SQLite` store.
+/// Run the database writer loop. Pulls submitted events from `event_rx`,
+/// runs validation (kind allow/blacklist, optional whitelist, NIP-05, gRPC
+/// admission, pay-to-relay), persists to the configured `NostrRepo`
+/// (SQLite or Postgres), and broadcasts saved events on `bcast_tx`.
 pub async fn db_writer(ctx: DbWriterContext) -> Result<()> {
     let DbWriterContext {
         repo,
@@ -461,9 +464,16 @@ pub async fn db_writer(ctx: DbWriterContext) -> Result<()> {
                 start.elapsed()
             );
             event_write = true;
+            metrics
+                .events_ephemeral_broadcast_by_kind
+                .with_label_values(&[&event.kind.to_string()])
+                .inc();
 
-            // send OK message. ephemeral events are broadcast but not persisted,
-            // so they intentionally do not bump events_persisted_by_kind.
+            // ephemeral events are broadcast but not persisted, so they bump
+            // events_ephemeral_broadcast_by_kind (above) instead of
+            // events_persisted_by_kind. This keeps the accounting identity
+            //   received = persisted + ephemeral_broadcast + rejected
+            // intact across all events.
             notice_tx.try_send(Notice::saved(event.id)).ok();
         } else {
             match repo.write_event(&event).await {

--- a/src/db.rs
+++ b/src/db.rs
@@ -98,18 +98,32 @@ async fn build_postgres_pool(settings: &Settings, metrics: NostrMetrics) -> Post
     repo
 }
 
+/// Wires the database writer to its inputs (event ingress, broadcast outputs,
+/// rate-limit / metrics state). Bundled into a struct so the function signature
+/// stays a single value as new dependencies are added.
+pub struct DbWriterContext {
+    pub repo: Arc<dyn NostrRepo>,
+    pub settings: Settings,
+    pub event_rx: tokio::sync::mpsc::Receiver<SubmittedEvent>,
+    pub bcast_tx: tokio::sync::broadcast::Sender<Event>,
+    pub metadata_tx: tokio::sync::broadcast::Sender<Event>,
+    pub payment_tx: tokio::sync::broadcast::Sender<PaymentMessage>,
+    pub shutdown: tokio::sync::broadcast::Receiver<()>,
+    pub metrics: NostrMetrics,
+}
+
 /// Spawn a database writer that persists events to the `SQLite` store.
-#[allow(clippy::too_many_arguments)]
-pub async fn db_writer(
-    repo: Arc<dyn NostrRepo>,
-    settings: Settings,
-    mut event_rx: tokio::sync::mpsc::Receiver<SubmittedEvent>,
-    bcast_tx: tokio::sync::broadcast::Sender<Event>,
-    metadata_tx: tokio::sync::broadcast::Sender<Event>,
-    payment_tx: tokio::sync::broadcast::Sender<PaymentMessage>,
-    mut shutdown: tokio::sync::broadcast::Receiver<()>,
-    metrics: NostrMetrics,
-) -> Result<()> {
+pub async fn db_writer(ctx: DbWriterContext) -> Result<()> {
+    let DbWriterContext {
+        repo,
+        settings,
+        mut event_rx,
+        bcast_tx,
+        metadata_tx,
+        payment_tx,
+        mut shutdown,
+        metrics,
+    } = ctx;
     // are we performing NIP-05 checking?
     let nip05_active = settings.verified_users.is_active();
     // are we requriing NIP-05 user verification?

--- a/src/db.rs
+++ b/src/db.rs
@@ -254,6 +254,10 @@ pub async fn db_writer(
                             notice_tx
                                 .try_send(Notice::blocked(event.id, "User is not admitted"))
                                 .ok();
+                            metrics
+                                .events_rejected
+                                .with_label_values(&["not_admitted"])
+                                .inc();
                             continue;
                         }
 
@@ -264,6 +268,10 @@ pub async fn db_writer(
                             notice_tx
                                 .try_send(Notice::blocked(event.id, "Insufficient balance"))
                                 .ok();
+                            metrics
+                                .events_rejected
+                                .with_label_values(&["insufficient_balance"])
+                                .inc();
                             continue;
                         }
                         user_balance = Some(balance);
@@ -282,6 +290,10 @@ pub async fn db_writer(
                         }
                         let msg = "Pubkey not registered";
                         notice_tx.try_send(Notice::error(event.id, msg)).ok();
+                        metrics
+                            .events_rejected
+                            .with_label_values(&["pubkey_not_registered"])
+                            .inc();
                         continue;
                     }
                     Err(err) => {
@@ -289,6 +301,10 @@ pub async fn db_writer(
                         let msg = "relay experienced an error checking your admission status";
                         notice_tx.try_send(Notice::error(event.id, msg)).ok();
                         // Other error
+                        metrics
+                            .events_rejected
+                            .with_label_values(&["admission_check_error"])
+                            .inc();
                         continue;
                     }
                 }
@@ -431,12 +447,9 @@ pub async fn db_writer(
                 start.elapsed()
             );
             event_write = true;
-            metrics
-                .events_persisted_by_kind
-                .with_label_values(&[&event.kind.to_string()])
-                .inc();
 
-            // send OK message
+            // send OK message. ephemeral events are broadcast but not persisted,
+            // so they intentionally do not bump events_persisted_by_kind.
             notice_tx.try_send(Notice::saved(event.id)).ok();
         } else {
             match repo.write_event(&event).await {

--- a/src/repo/mod.rs
+++ b/src/repo/mod.rs
@@ -86,6 +86,18 @@ pub trait NostrRepo: Send + Sync {
     /// Get the most recent invoice for a given pubkey
     /// invoice must be unpaid and not expired
     async fn get_unpaid_invoice(&self, pubkey: &Keys) -> Result<Option<InvoiceInfo>>;
+
+    /// Estimated total event count in the database
+    async fn count_events_total(&self) -> Result<i64>;
+
+    /// Event counts grouped by kind: `Vec<(kind, count)>`
+    async fn count_events_by_kind(&self) -> Result<Vec<(i64, i64)>>;
+
+    /// Distinct authors in the events table (estimate where supported)
+    async fn count_distinct_authors_estimate(&self) -> Result<i64>;
+
+    /// Database size on disk in bytes
+    async fn db_size_bytes(&self) -> Result<i64>;
 }
 
 // Current time, with a slight forward jitter in seconds

--- a/src/repo/postgres.rs
+++ b/src/repo/postgres.rs
@@ -743,8 +743,13 @@ LIMIT 1;
     async fn count_distinct_authors_estimate(&self) -> Result<i64> {
         // pg_stats.n_distinct: positive = absolute distinct count;
         // negative = fraction of total rows. Postgres maintains this via ANALYZE.
+        // Schema-qualify so that an `event` table in another schema (or two
+        // matching rows from search_path overlap) can't return the wrong stats.
         let row: Option<(Option<f32>,)> = sqlx::query_as(
-            "SELECT n_distinct FROM pg_stats WHERE tablename = 'event' AND attname = 'pub_key'",
+            "SELECT n_distinct FROM pg_stats \
+             WHERE schemaname = 'public' \
+               AND tablename = 'event' \
+               AND attname = 'pub_key'",
         )
         .fetch_optional(&self.conn)
         .await

--- a/src/repo/postgres.rs
+++ b/src/repo/postgres.rs
@@ -715,12 +715,18 @@ LIMIT 1;
         // pg_class.reltuples is a planner estimate maintained by ANALYZE/autovacuum.
         // It avoids a sequential scan on large tables. Negative values can occur
         // before the table has been analyzed; clamp to zero in that case.
-        let row: (Option<f32>,) =
-            sqlx::query_as("SELECT reltuples FROM pg_class WHERE relname = 'event'")
-                .fetch_optional(&self.conn)
-                .await
-                .map_err(error::Error::SqlxError)?
-                .unwrap_or((Some(0.0),));
+        // Scope by relkind ('r' = ordinary table) and namespace so we don't match
+        // toast tables, indexes, or same-named relations in another schema.
+        let row: (Option<f32>,) = sqlx::query_as(
+            "SELECT reltuples FROM pg_class \
+             WHERE relname = 'event' \
+               AND relkind = 'r' \
+               AND relnamespace = 'public'::regnamespace",
+        )
+        .fetch_optional(&self.conn)
+        .await
+        .map_err(error::Error::SqlxError)?
+        .unwrap_or((Some(0.0),));
         let est = row.0.unwrap_or(0.0).max(0.0) as i64;
         Ok(est)
     }
@@ -743,7 +749,25 @@ LIMIT 1;
         .fetch_optional(&self.conn)
         .await
         .map_err(error::Error::SqlxError)?;
-        let n_distinct = row.and_then(|r| r.0).unwrap_or(0.0);
+        let n_distinct = match row.and_then(|r| r.0) {
+            Some(v) => v,
+            None => {
+                // pg_stats is empty for this column. Most common cause: ANALYZE has
+                // not run yet on a fresh table; less common: the connecting role
+                // lacks SELECT on the table (pg_stats is privilege-filtered). Warn
+                // once so an operator sees the issue instead of a silent zero.
+                static WARNED: std::sync::atomic::AtomicBool =
+                    std::sync::atomic::AtomicBool::new(false);
+                if !WARNED.swap(true, std::sync::atomic::Ordering::Relaxed) {
+                    warn!(
+                        "pg_stats has no row for event.pub_key; \
+                         distinct-authors metric will read 0 until ANALYZE runs \
+                         (or until the connecting role gains SELECT on event)"
+                    );
+                }
+                0.0
+            }
+        };
         if n_distinct >= 0.0 {
             Ok(n_distinct as i64)
         } else {

--- a/src/repo/postgres.rs
+++ b/src/repo/postgres.rs
@@ -710,6 +710,56 @@ LIMIT 1;
             None => Ok(None),
         }
     }
+
+    async fn count_events_total(&self) -> Result<i64> {
+        // pg_class.reltuples is a planner estimate maintained by ANALYZE/autovacuum.
+        // It avoids a sequential scan on large tables. Negative values can occur
+        // before the table has been analyzed; clamp to zero in that case.
+        let row: (Option<f32>,) =
+            sqlx::query_as("SELECT reltuples FROM pg_class WHERE relname = 'event'")
+                .fetch_optional(&self.conn)
+                .await
+                .map_err(error::Error::SqlxError)?
+                .unwrap_or((Some(0.0),));
+        let est = row.0.unwrap_or(0.0).max(0.0) as i64;
+        Ok(est)
+    }
+
+    async fn count_events_by_kind(&self) -> Result<Vec<(i64, i64)>> {
+        let rows: Vec<(i32, i64)> =
+            sqlx::query_as("SELECT kind, COUNT(*)::bigint FROM event GROUP BY kind")
+                .fetch_all(&self.conn)
+                .await
+                .map_err(error::Error::SqlxError)?;
+        Ok(rows.into_iter().map(|(k, c)| (k as i64, c)).collect())
+    }
+
+    async fn count_distinct_authors_estimate(&self) -> Result<i64> {
+        // pg_stats.n_distinct: positive = absolute distinct count;
+        // negative = fraction of total rows. Postgres maintains this via ANALYZE.
+        let row: Option<(Option<f32>,)> = sqlx::query_as(
+            "SELECT n_distinct FROM pg_stats WHERE tablename = 'event' AND attname = 'pub_key'",
+        )
+        .fetch_optional(&self.conn)
+        .await
+        .map_err(error::Error::SqlxError)?;
+        let n_distinct = row.and_then(|r| r.0).unwrap_or(0.0);
+        if n_distinct >= 0.0 {
+            Ok(n_distinct as i64)
+        } else {
+            // negative => -(fraction of total rows)
+            let total = self.count_events_total().await? as f32;
+            Ok((-n_distinct * total) as i64)
+        }
+    }
+
+    async fn db_size_bytes(&self) -> Result<i64> {
+        let (size,): (i64,) = sqlx::query_as("SELECT pg_database_size(current_database())")
+            .fetch_one(&self.conn)
+            .await
+            .map_err(error::Error::SqlxError)?;
+        Ok(size)
+    }
 }
 
 /// Create a dynamic SQL query and params from a subscription filter.

--- a/src/repo/sqlite.rs
+++ b/src/repo/sqlite.rs
@@ -967,12 +967,18 @@ LIMIT 1;
     }
 
     async fn db_size_bytes(&self) -> Result<i64> {
+        // Size of the main DB file in pages (excludes -wal / -shm sidecars in
+        // WAL mode; see docs/metrics.md). Production runs Postgres, where
+        // pg_database_size is correct.
         let pool = self.read_pool.clone();
         let size = task::spawn_blocking(move || -> Result<i64> {
             let conn = pool.get()?;
             let pages: i64 = conn.query_row("PRAGMA page_count", [], |r| r.get(0))?;
             let page_size: i64 = conn.query_row("PRAGMA page_size", [], |r| r.get(0))?;
-            Ok(pages * page_size)
+            // Widen through i128 so a pathological large-DB multiplication
+            // can't silently wrap. i64 caps at ~9.2 EiB, well past realistic.
+            let bytes = (pages as i128).saturating_mul(page_size as i128);
+            Ok(i64::try_from(bytes).unwrap_or(i64::MAX))
         })
         .await??;
         Ok(size)

--- a/src/repo/sqlite.rs
+++ b/src/repo/sqlite.rs
@@ -923,6 +923,51 @@ LIMIT 1;
             confirmed_at: None,
         }))
     }
+
+    async fn count_events_total(&self) -> Result<i64> {
+        let conn = self.read_pool.get()?;
+        let count = task::spawn_blocking(move || -> Result<i64> {
+            let n: i64 = conn.query_row("SELECT COUNT(*) FROM event", [], |r| r.get(0))?;
+            Ok(n)
+        })
+        .await??;
+        Ok(count)
+    }
+
+    async fn count_events_by_kind(&self) -> Result<Vec<(i64, i64)>> {
+        let conn = self.read_pool.get()?;
+        let rows = task::spawn_blocking(move || -> Result<Vec<(i64, i64)>> {
+            let mut stmt = conn.prepare("SELECT kind, COUNT(*) FROM event GROUP BY kind")?;
+            let rows = stmt
+                .query_map([], |r| Ok((r.get::<_, i64>(0)?, r.get::<_, i64>(1)?)))?
+                .collect::<std::result::Result<Vec<_>, _>>()?;
+            Ok(rows)
+        })
+        .await??;
+        Ok(rows)
+    }
+
+    async fn count_distinct_authors_estimate(&self) -> Result<i64> {
+        let conn = self.read_pool.get()?;
+        let count = task::spawn_blocking(move || -> Result<i64> {
+            let n: i64 =
+                conn.query_row("SELECT COUNT(DISTINCT author) FROM event", [], |r| r.get(0))?;
+            Ok(n)
+        })
+        .await??;
+        Ok(count)
+    }
+
+    async fn db_size_bytes(&self) -> Result<i64> {
+        let conn = self.read_pool.get()?;
+        let size = task::spawn_blocking(move || -> Result<i64> {
+            let pages: i64 = conn.query_row("PRAGMA page_count", [], |r| r.get(0))?;
+            let page_size: i64 = conn.query_row("PRAGMA page_size", [], |r| r.get(0))?;
+            Ok(pages * page_size)
+        })
+        .await??;
+        Ok(size)
+    }
 }
 
 /// Decide if there is an index that should be used explicitly

--- a/src/repo/sqlite.rs
+++ b/src/repo/sqlite.rs
@@ -925,8 +925,11 @@ LIMIT 1;
     }
 
     async fn count_events_total(&self) -> Result<i64> {
-        let conn = self.read_pool.get()?;
+        // pool.get() blocks if the pool is saturated; do it inside spawn_blocking
+        // so we don't park an async executor thread waiting for a connection.
+        let pool = self.read_pool.clone();
         let count = task::spawn_blocking(move || -> Result<i64> {
+            let conn = pool.get()?;
             let n: i64 = conn.query_row("SELECT COUNT(*) FROM event", [], |r| r.get(0))?;
             Ok(n)
         })
@@ -935,8 +938,9 @@ LIMIT 1;
     }
 
     async fn count_events_by_kind(&self) -> Result<Vec<(i64, i64)>> {
-        let conn = self.read_pool.get()?;
+        let pool = self.read_pool.clone();
         let rows = task::spawn_blocking(move || -> Result<Vec<(i64, i64)>> {
+            let conn = pool.get()?;
             let mut stmt = conn.prepare("SELECT kind, COUNT(*) FROM event GROUP BY kind")?;
             let rows = stmt
                 .query_map([], |r| Ok((r.get::<_, i64>(0)?, r.get::<_, i64>(1)?)))?
@@ -948,8 +952,12 @@ LIMIT 1;
     }
 
     async fn count_distinct_authors_estimate(&self) -> Result<i64> {
-        let conn = self.read_pool.get()?;
+        // SQLite has no n_distinct estimate; this runs an exact COUNT(DISTINCT).
+        // Fine for the test harness (in-memory DBs); production runs on Postgres
+        // which uses pg_stats.n_distinct. See docs/metrics.md.
+        let pool = self.read_pool.clone();
         let count = task::spawn_blocking(move || -> Result<i64> {
+            let conn = pool.get()?;
             let n: i64 =
                 conn.query_row("SELECT COUNT(DISTINCT author) FROM event", [], |r| r.get(0))?;
             Ok(n)
@@ -959,8 +967,9 @@ LIMIT 1;
     }
 
     async fn db_size_bytes(&self) -> Result<i64> {
-        let conn = self.read_pool.get()?;
+        let pool = self.read_pool.clone();
         let size = task::spawn_blocking(move || -> Result<i64> {
+            let conn = pool.get()?;
             let pages: i64 = conn.query_row("PRAGMA page_count", [], |r| r.get(0))?;
             let page_size: i64 = conn.query_row("PRAGMA page_size", [], |r| r.get(0))?;
             Ok(pages * page_size)

--- a/src/server.rs
+++ b/src/server.rs
@@ -855,7 +855,8 @@ fn create_metrics() -> (Registry, NostrMetrics) {
     (registry, metrics)
 }
 
-async fn collect_state_metrics(repo: &dyn NostrRepo, m: &NostrMetrics) {
+/// Fast-tick collector: cheap state queries safe to run every 30s on a busy DB.
+async fn collect_fast_state_metrics(repo: &dyn NostrRepo, m: &NostrMetrics) {
     match repo.count_events_total().await {
         Ok(n) => m.db_events_total.set(n),
         Err(e) => warn!("metrics: count_events_total failed: {e}"),
@@ -868,15 +869,34 @@ async fn collect_state_metrics(repo: &dyn NostrRepo, m: &NostrMetrics) {
         Ok(n) => m.db_size_bytes.set(n),
         Err(e) => warn!("metrics: db_size_bytes failed: {e}"),
     }
+}
+
+/// Slow-tick collector: per-kind GROUP BY is a seq scan on Postgres. Run on a
+/// 10-minute cadence to keep the dashboard fresh without thrashing the buffer cache.
+async fn collect_slow_state_metrics(
+    repo: &dyn NostrRepo,
+    m: &NostrMetrics,
+    prev_kinds: &mut std::collections::HashSet<String>,
+) {
     match repo.count_events_by_kind().await {
         Ok(rows) => {
-            // reset to zero before applying current counts so kinds that vanished are dropped
-            m.db_events_by_kind.reset();
+            let mut seen = std::collections::HashSet::with_capacity(rows.len());
             for (kind, count) in rows {
+                let label = kind.to_string();
                 m.db_events_by_kind
-                    .with_label_values(&[&kind.to_string()])
+                    .with_label_values(&[&label])
                     .set(count);
+                seen.insert(label);
             }
+            // Remove labels for kinds we set previously but didn't see this cycle.
+            // Doing diff-then-remove avoids the visible scrape gap that a blanket
+            // reset() would cause.
+            for stale in prev_kinds.difference(&seen) {
+                m.db_events_by_kind
+                    .remove_label_values(&[stale.as_str()])
+                    .ok();
+            }
+            *prev_kinds = seen;
         }
         Err(e) => warn!("metrics: count_events_by_kind failed: {e}"),
     }
@@ -1000,25 +1020,40 @@ pub fn start_server(settings: &Settings, shutdown_rx: MpscReceiver<()>) -> Resul
         ));
         info!("db writer created");
 
-        // background collector for state-of-the-database gauges
+        // background collector for state-of-the-database gauges. Two intervals:
+        //   - fast (30s): cheap queries (reltuples estimate, db size, distinct authors)
+        //   - slow (10min): per-kind GROUP BY which is a sequential scan on Postgres
         let collector_repo = repo.clone();
         let collector_metrics = metrics.clone();
         let mut collector_shutdown = invoke_shutdown.subscribe();
         tokio::task::spawn(async move {
-            let interval = Duration::from_secs(30);
-            // do a first collection pass shortly after startup, then on the interval
-            let mut tick = tokio::time::interval_at(
+            let mut fast_tick = tokio::time::interval_at(
                 tokio::time::Instant::now() + Duration::from_secs(5),
-                interval,
+                Duration::from_secs(30),
             );
+            let mut slow_tick = tokio::time::interval_at(
+                tokio::time::Instant::now() + Duration::from_secs(15),
+                Duration::from_secs(600),
+            );
+            // remember which kind labels we set last cycle, so we can drop labels
+            // for kinds that vanished without a window where the gauge is missing.
+            let mut prev_kinds: std::collections::HashSet<String> =
+                std::collections::HashSet::new();
             loop {
                 tokio::select! {
                     _ = collector_shutdown.recv() => {
                         info!("metrics collector shutting down");
                         break;
                     }
-                    _ = tick.tick() => {
-                        collect_state_metrics(collector_repo.as_ref(), &collector_metrics).await;
+                    _ = fast_tick.tick() => {
+                        collect_fast_state_metrics(collector_repo.as_ref(), &collector_metrics).await;
+                    }
+                    _ = slow_tick.tick() => {
+                        collect_slow_state_metrics(
+                            collector_repo.as_ref(),
+                            &collector_metrics,
+                            &mut prev_kinds,
+                        ).await;
                     }
                 }
             }
@@ -1294,9 +1329,10 @@ async fn nostr_server(
         cid, origin, user_agent
     );
 
-    // Measure connections
+    // Measure connections. The guard handles connections_active + per-conn
+    // subscriptions_active accounting, including panic / early-return safety.
     metrics.connections.inc();
-    metrics.connections_active.inc();
+    let lifecycle = ConnLifecycleGuard::new(metrics.clone());
 
     if settings.authorization.nip42_auth {
         conn.generate_auth_challenge();
@@ -1469,6 +1505,7 @@ async fn nostr_server(
                                 debug!("successfully parsed/validated event: {:?} (cid: {}, kind: {})", id_prefix, cid, e.kind);
                                 // check if event is expired
                                 if e.is_expired() {
+                                    metrics.events_rejected.with_label_values(&["expired"]).inc();
                                     let notice = Notice::invalid(e.id, "The event has already expired");
                                     if ws_stream.send(make_notice_message(&notice)).await.is_err() {
                                         debug!("failed to send notice, closing connection (cid: {})", cid);
@@ -1489,6 +1526,7 @@ async fn nostr_server(
                                     event_tx.send(submit_event).await.ok();
                                     client_published_event_count += 1;
                                 } else {
+                                    metrics.events_rejected.with_label_values(&["future_dated"]).inc();
                                     info!("client: {} sent a far future-dated event", cid);
                                     if let Some(fut_sec) = settings.options.reject_future_seconds {
                                         let msg = format!("The event created_at field is out of the acceptable range (+{fut_sec}sec) for this relay.");
@@ -1591,7 +1629,7 @@ async fn nostr_server(
                                     if let Some(previous_query) = running_queries.insert(s.id.clone(), abandon_query_tx) {
                                         previous_query.send(()).ok();
                                     } else {
-                                        metrics.subscriptions_active.inc();
+                                        lifecycle.sub_added();
                                     }
                                     if s.needs_historical_events() {
                                         // start a database query.  this spawns a blocking database query on a worker thread.
@@ -1626,7 +1664,7 @@ async fn nostr_server(
                             let had_sub = conn.subscriptions().contains_key(&c.id);
                             conn.unsubscribe(&c);
                             if had_sub {
-                                metrics.subscriptions_active.dec();
+                                lifecycle.sub_removed();
                             }
                         } else {
                             info!("invalid command ignored");
@@ -1668,11 +1706,9 @@ async fn nostr_server(
     for (_, stop_tx) in running_queries {
         stop_tx.send(()).ok();
     }
-    // any subscriptions left attached to the connection are now dropped
-    metrics
-        .subscriptions_active
-        .sub(conn.subscriptions().len() as i64);
-    metrics.connections_active.dec();
+    // lifecycle guard drops here, decrementing connections_active and any
+    // remaining subscriptions_active count.
+    drop(lifecycle);
     info!(
         "stopping client connection (cid: {}, ip: {:?}, sent: {} events, recv: {} events, connected: {:?})",
         cid,
@@ -1681,6 +1717,43 @@ async fn nostr_server(
         client_received_event_count,
         orig_start.elapsed()
     );
+}
+
+/// Decrements connection and subscription gauges when dropped, so the gauges
+/// stay correct even if the connection task panics or returns early.
+struct ConnLifecycleGuard {
+    metrics: NostrMetrics,
+    held_subs: std::cell::Cell<i64>,
+}
+
+impl ConnLifecycleGuard {
+    fn new(metrics: NostrMetrics) -> Self {
+        metrics.connections_active.inc();
+        Self {
+            metrics,
+            held_subs: std::cell::Cell::new(0),
+        }
+    }
+
+    fn sub_added(&self) {
+        self.metrics.subscriptions_active.inc();
+        self.held_subs.set(self.held_subs.get() + 1);
+    }
+
+    fn sub_removed(&self) {
+        self.metrics.subscriptions_active.dec();
+        self.held_subs.set(self.held_subs.get() - 1);
+    }
+}
+
+impl Drop for ConnLifecycleGuard {
+    fn drop(&mut self) {
+        let remaining = self.held_subs.get();
+        if remaining > 0 {
+            self.metrics.subscriptions_active.sub(remaining);
+        }
+        self.metrics.connections_active.dec();
+    }
 }
 
 #[derive(Clone)]

--- a/src/server.rs
+++ b/src/server.rs
@@ -777,6 +777,14 @@ fn create_metrics() -> (Registry, NostrMetrics) {
         vec!["kind"].as_slice(),
     )
     .unwrap();
+    let events_ephemeral_broadcast_by_kind = IntCounterVec::new(
+        Opts::new(
+            "nostr_events_ephemeral_broadcast_by_kind_total",
+            "Ephemeral events broadcast to subscribers (not persisted), by kind",
+        ),
+        vec!["kind"].as_slice(),
+    )
+    .unwrap();
     let events_rejected = IntCounterVec::new(
         Opts::new(
             "nostr_events_rejected_total",
@@ -824,6 +832,7 @@ fn create_metrics() -> (Registry, NostrMetrics) {
     registry.register(Box::new(subscriptions_active.clone())).unwrap();
     registry.register(Box::new(events_received_by_kind.clone())).unwrap();
     registry.register(Box::new(events_persisted_by_kind.clone())).unwrap();
+    registry.register(Box::new(events_ephemeral_broadcast_by_kind.clone())).unwrap();
     registry.register(Box::new(events_rejected.clone())).unwrap();
     registry.register(Box::new(db_events_total.clone())).unwrap();
     registry.register(Box::new(db_events_by_kind.clone())).unwrap();
@@ -846,6 +855,7 @@ fn create_metrics() -> (Registry, NostrMetrics) {
         subscriptions_active,
         events_received_by_kind,
         events_persisted_by_kind,
+        events_ephemeral_broadcast_by_kind,
         events_rejected,
         db_events_total,
         db_events_by_kind,
@@ -1620,15 +1630,22 @@ async fn nostr_server(
                                 }
                                 continue
                             }
+                            // Snapshot whether the sub-id is already registered BEFORE
+                            // calling subscribe(), since subscribe() silently replaces an
+                            // entry with the same id. running_queries.insert() returning
+                            // None is *not* a reliable proxy for "newly created" — a sub
+                            // that doesn't need historical events never put an entry in
+                            // running_queries, so on re-subscribe with new filters we'd
+                            // overcount the subscriptions_active gauge.
+                            let had_sub = conn.subscriptions().contains_key(&s.id);
                             let (abandon_query_tx, abandon_query_rx) = oneshot::channel::<()>();
                             match conn.subscribe(s.clone()) {
                                 Ok(()) => {
-                                    // when we insert, if there was a previous query running with the same name, cancel it.
-                                    // sub IDs are unique per-connection: a re-subscribe with a duplicate ID
-                                    // replaces the previous one rather than adding a new entry.
+                                    // cancel any running query for this sub id
                                     if let Some(previous_query) = running_queries.insert(s.id.clone(), abandon_query_tx) {
                                         previous_query.send(()).ok();
-                                    } else {
+                                    }
+                                    if !had_sub {
                                         lifecycle.sub_added();
                                     }
                                     if s.needs_historical_events() {
@@ -1774,6 +1791,7 @@ pub struct NostrMetrics {
     pub subscriptions_active: IntGauge, // currently active REQ subscriptions
     pub events_received_by_kind: IntCounterVec, // valid events received from clients, by kind
     pub events_persisted_by_kind: IntCounterVec, // events successfully persisted, by kind
+    pub events_ephemeral_broadcast_by_kind: IntCounterVec, // ephemeral events broadcast, by kind
     pub events_rejected: IntCounterVec, // events rejected before persistence, by reason
     pub db_events_total: IntGauge,   // estimated total events in DB
     pub db_events_by_kind: IntGaugeVec, // event count per kind in DB

--- a/src/server.rs
+++ b/src/server.rs
@@ -34,6 +34,7 @@ use nostr::key::FromPkStr;
 use nostr::key::Keys;
 use prometheus::IntCounterVec;
 use prometheus::IntGauge;
+use prometheus::IntGaugeVec;
 use prometheus::{Encoder, Histogram, HistogramOpts, IntCounter, Opts, Registry, TextEncoder};
 use qrcode::render::svg;
 use qrcode::QrCode;
@@ -697,6 +698,15 @@ fn create_metrics() -> (Registry, NostrMetrics) {
     // setup prometheus registry
     let registry = Registry::new();
 
+    // process_collector is Linux-only (procfs-backed). Production runs in Docker/ECS
+    // (Linux); this block is skipped on macOS, so /metrics omits process_* there.
+    #[cfg(target_os = "linux")]
+    registry
+        .register(Box::new(
+            prometheus::process_collector::ProcessCollector::for_self(),
+        ))
+        .unwrap();
+
     let query_sub = Histogram::with_opts(HistogramOpts::new(
         "nostr_query_seconds",
         "Subscription response times",
@@ -741,6 +751,63 @@ fn create_metrics() -> (Registry, NostrMetrics) {
         vec!["reason"].as_slice(),
     )
     .unwrap();
+    let connections_active = IntGauge::with_opts(Opts::new(
+        "nostr_connections_active",
+        "Active WebSocket connections",
+    ))
+    .unwrap();
+    let subscriptions_active = IntGauge::with_opts(Opts::new(
+        "nostr_subscriptions_active",
+        "Active REQ subscriptions across all clients",
+    ))
+    .unwrap();
+    let events_received_by_kind = IntCounterVec::new(
+        Opts::new(
+            "nostr_events_received_by_kind_total",
+            "Valid events received from clients, by kind",
+        ),
+        vec!["kind"].as_slice(),
+    )
+    .unwrap();
+    let events_persisted_by_kind = IntCounterVec::new(
+        Opts::new(
+            "nostr_events_persisted_by_kind_total",
+            "Events successfully persisted to the database, by kind",
+        ),
+        vec!["kind"].as_slice(),
+    )
+    .unwrap();
+    let events_rejected = IntCounterVec::new(
+        Opts::new(
+            "nostr_events_rejected_total",
+            "Events rejected before persistence, by reason",
+        ),
+        vec!["reason"].as_slice(),
+    )
+    .unwrap();
+    let db_events_total = IntGauge::with_opts(Opts::new(
+        "nostr_db_events_total",
+        "Estimated total events stored in the database",
+    ))
+    .unwrap();
+    let db_events_by_kind = IntGaugeVec::new(
+        Opts::new(
+            "nostr_db_events_by_kind",
+            "Events stored in the database, by kind",
+        ),
+        vec!["kind"].as_slice(),
+    )
+    .unwrap();
+    let db_authors_distinct = IntGauge::with_opts(Opts::new(
+        "nostr_db_authors_distinct",
+        "Distinct event authors in the database (estimate)",
+    ))
+    .unwrap();
+    let db_size_bytes = IntGauge::with_opts(Opts::new(
+        "nostr_db_size_bytes",
+        "Size of the database on disk, in bytes",
+    ))
+    .unwrap();
     registry.register(Box::new(query_sub.clone())).unwrap();
     registry.register(Box::new(query_db.clone())).unwrap();
     registry.register(Box::new(write_events.clone())).unwrap();
@@ -753,6 +820,15 @@ fn create_metrics() -> (Registry, NostrMetrics) {
     registry.register(Box::new(cmd_close.clone())).unwrap();
     registry.register(Box::new(cmd_auth.clone())).unwrap();
     registry.register(Box::new(disconnects.clone())).unwrap();
+    registry.register(Box::new(connections_active.clone())).unwrap();
+    registry.register(Box::new(subscriptions_active.clone())).unwrap();
+    registry.register(Box::new(events_received_by_kind.clone())).unwrap();
+    registry.register(Box::new(events_persisted_by_kind.clone())).unwrap();
+    registry.register(Box::new(events_rejected.clone())).unwrap();
+    registry.register(Box::new(db_events_total.clone())).unwrap();
+    registry.register(Box::new(db_events_by_kind.clone())).unwrap();
+    registry.register(Box::new(db_authors_distinct.clone())).unwrap();
+    registry.register(Box::new(db_size_bytes.clone())).unwrap();
     let metrics = NostrMetrics {
         query_sub,
         query_db,
@@ -766,8 +842,44 @@ fn create_metrics() -> (Registry, NostrMetrics) {
         cmd_event,
         cmd_close,
         cmd_auth,
+        connections_active,
+        subscriptions_active,
+        events_received_by_kind,
+        events_persisted_by_kind,
+        events_rejected,
+        db_events_total,
+        db_events_by_kind,
+        db_authors_distinct,
+        db_size_bytes,
     };
     (registry, metrics)
+}
+
+async fn collect_state_metrics(repo: &dyn NostrRepo, m: &NostrMetrics) {
+    match repo.count_events_total().await {
+        Ok(n) => m.db_events_total.set(n),
+        Err(e) => warn!("metrics: count_events_total failed: {e}"),
+    }
+    match repo.count_distinct_authors_estimate().await {
+        Ok(n) => m.db_authors_distinct.set(n),
+        Err(e) => warn!("metrics: count_distinct_authors_estimate failed: {e}"),
+    }
+    match repo.db_size_bytes().await {
+        Ok(n) => m.db_size_bytes.set(n),
+        Err(e) => warn!("metrics: db_size_bytes failed: {e}"),
+    }
+    match repo.count_events_by_kind().await {
+        Ok(rows) => {
+            // reset to zero before applying current counts so kinds that vanished are dropped
+            m.db_events_by_kind.reset();
+            for (kind, count) in rows {
+                m.db_events_by_kind
+                    .with_label_values(&[&kind.to_string()])
+                    .set(count);
+            }
+        }
+        Err(e) => warn!("metrics: count_events_by_kind failed: {e}"),
+    }
 }
 
 fn file_bytes(path: &str) -> Result<Vec<u8>> {
@@ -884,8 +996,33 @@ pub fn start_server(settings: &Settings, shutdown_rx: MpscReceiver<()>) -> Resul
             metadata_tx.clone(),
             payment_tx.clone(),
             shutdown_listen,
+            metrics.clone(),
         ));
         info!("db writer created");
+
+        // background collector for state-of-the-database gauges
+        let collector_repo = repo.clone();
+        let collector_metrics = metrics.clone();
+        let mut collector_shutdown = invoke_shutdown.subscribe();
+        tokio::task::spawn(async move {
+            let interval = Duration::from_secs(30);
+            // do a first collection pass shortly after startup, then on the interval
+            let mut tick = tokio::time::interval_at(
+                tokio::time::Instant::now() + Duration::from_secs(5),
+                interval,
+            );
+            loop {
+                tokio::select! {
+                    _ = collector_shutdown.recv() => {
+                        info!("metrics collector shutting down");
+                        break;
+                    }
+                    _ = tick.tick() => {
+                        collect_state_metrics(collector_repo.as_ref(), &collector_metrics).await;
+                    }
+                }
+            }
+        });
 
         // create a nip-05 verifier thread; if enabled.
         if settings.verified_users.mode != VerifiedUsersMode::Disabled {
@@ -1159,6 +1296,7 @@ async fn nostr_server(
 
     // Measure connections
     metrics.connections.inc();
+    metrics.connections_active.inc();
 
     if settings.authorization.nip42_auth {
         conn.generate_auth_challenge();
@@ -1323,6 +1461,10 @@ async fn nostr_server(
                         match parsed {
                             Ok(WrappedEvent(e)) => {
                                 metrics.cmd_event.inc();
+                                metrics
+                                    .events_received_by_kind
+                                    .with_label_values(&[&e.kind.to_string()])
+                                    .inc();
                                 let id_prefix:String = e.id.chars().take(8).collect();
                                 debug!("successfully parsed/validated event: {:?} (cid: {}, kind: {})", id_prefix, cid, e.kind);
                                 // check if event is expired
@@ -1444,8 +1586,12 @@ async fn nostr_server(
                             match conn.subscribe(s.clone()) {
                                 Ok(()) => {
                                     // when we insert, if there was a previous query running with the same name, cancel it.
+                                    // sub IDs are unique per-connection: a re-subscribe with a duplicate ID
+                                    // replaces the previous one rather than adding a new entry.
                                     if let Some(previous_query) = running_queries.insert(s.id.clone(), abandon_query_tx) {
                                         previous_query.send(()).ok();
+                                    } else {
+                                        metrics.subscriptions_active.inc();
                                     }
                                     if s.needs_historical_events() {
                                         // start a database query.  this spawns a blocking database query on a worker thread.
@@ -1477,7 +1623,11 @@ async fn nostr_server(
                             }
                             // stop checking new events against
                             // the subscription
+                            let had_sub = conn.subscriptions().contains_key(&c.id);
                             conn.unsubscribe(&c);
+                            if had_sub {
+                                metrics.subscriptions_active.dec();
+                            }
                         } else {
                             info!("invalid command ignored");
                             if ws_stream.send(make_notice_message(&Notice::message("could not parse command".into()))).await.is_err() {
@@ -1518,6 +1668,11 @@ async fn nostr_server(
     for (_, stop_tx) in running_queries {
         stop_tx.send(()).ok();
     }
+    // any subscriptions left attached to the connection are now dropped
+    metrics
+        .subscriptions_active
+        .sub(conn.subscriptions().len() as i64);
+    metrics.connections_active.dec();
     info!(
         "stopping client connection (cid: {}, ip: {:?}, sent: {} events, recv: {} events, connected: {:?})",
         cid,
@@ -1542,4 +1697,13 @@ pub struct NostrMetrics {
     pub cmd_event: IntCounter,       // count of EVENT commands received
     pub cmd_close: IntCounter,       // count of CLOSE commands received
     pub cmd_auth: IntCounter,        // count of AUTH commands received
+    pub connections_active: IntGauge, // currently open WebSocket connections
+    pub subscriptions_active: IntGauge, // currently active REQ subscriptions
+    pub events_received_by_kind: IntCounterVec, // valid events received from clients, by kind
+    pub events_persisted_by_kind: IntCounterVec, // events successfully persisted, by kind
+    pub events_rejected: IntCounterVec, // events rejected before persistence, by reason
+    pub db_events_total: IntGauge,   // estimated total events in DB
+    pub db_events_by_kind: IntGaugeVec, // event count per kind in DB
+    pub db_authors_distinct: IntGauge, // distinct authors in DB (estimate)
+    pub db_size_bytes: IntGauge,     // database size on disk
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1008,16 +1008,16 @@ pub fn start_server(settings: &Settings, shutdown_rx: MpscReceiver<()>) -> Resul
         // start the database writer task.  Give it a channel for
         // writing events, and for publishing events that have been
         // written (to all connected clients).
-        tokio::task::spawn(db::db_writer(
-            repo.clone(),
-            settings.clone(),
+        tokio::task::spawn(db::db_writer(db::DbWriterContext {
+            repo: repo.clone(),
+            settings: settings.clone(),
             event_rx,
-            bcast_tx.clone(),
-            metadata_tx.clone(),
-            payment_tx.clone(),
-            shutdown_listen,
-            metrics.clone(),
-        ));
+            bcast_tx: bcast_tx.clone(),
+            metadata_tx: metadata_tx.clone(),
+            payment_tx: payment_tx.clone(),
+            shutdown: shutdown_listen,
+            metrics: metrics.clone(),
+        }));
         info!("db writer created");
 
         // background collector for state-of-the-database gauges. Two intervals:


### PR DESCRIPTION
Closes #1.

## Summary

- Adds per-kind event flow counters (`events_received_by_kind`, `events_persisted_by_kind`) and a `events_rejected{reason}` counter covering every `db_writer` reject branch.
- Adds live gauges (`connections_active`, `subscriptions_active`) and a 30s background collector that populates DB state gauges (`db_events_total`, `db_events_by_kind{kind}`, `db_authors_distinct`, `db_size_bytes`). Postgres queries use `pg_class.reltuples`, `pg_stats.n_distinct`, and `pg_database_size` to avoid sequential scans.
- Registers the Linux `process_collector` so `/metrics` exposes `process_cpu_seconds_total`, `process_resident_memory_bytes`, `process_open_fds`, etc. (no-op on macOS dev builds).
- Adds an Alloy + cAdvisor sidecar stack (`alloy/config.alloy`, `docker-compose.metrics.yml`) that scrapes relay + cAdvisor and remote-writes to Grafana Cloud through env-driven creds — same pattern as our zooid relay.
- Documents every series, label cardinality, and the RDS-via-CloudWatch path in `docs/metrics.md`.

Phase 2 (Unicity-specific metrics for ID bindings and token transfers) is intentionally out of scope and will land in a follow-up issue once we have the SDK / event-kind layout.

## Test plan

- [x] `cargo check` clean
- [x] `cargo clippy` clean (only pre-existing warnings remain)
- [x] `cargo test --all` passes (83 + 13 + 2 + 1 tests)
- [ ] Manual: `docker compose -f docker-compose.metrics.yml up`, confirm relay `/metrics` shows new series and Alloy receives both relay and cAdvisor scrapes
- [ ] Manual: confirm series appear in Grafana Cloud with the expected env-var creds