### PR TITLE
fix: lower default ping_interval to 45s; scale max_quiet_time to it

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -99,6 +99,9 @@ port = 8080
 # Set this below the idle timeout of any reverse proxy or middlebox between
 # the client and the relay. Common values: AWS ALB default 60s, Cloudflare
 # ~100s, mobile/CGNAT idle timeouts often 60–300s.
+# NOTE: an older revision of this example showed `ping_interval` (no
+# `_seconds`); that key was always silently ignored. If you copied it,
+# rename to `ping_interval_seconds`.
 #ping_interval_seconds = 45
 
 [options]

--- a/config.toml
+++ b/config.toml
@@ -95,8 +95,11 @@ port = 8080
 #remote_ip_header = "x-forwarded-for"
 #remote_ip_header = "cf-connecting-ip"
 
-# Websocket ping interval in seconds, defaults to 5 minutes
-#ping_interval = 300
+# WebSocket keep-alive ping interval, in seconds. Default is 45.
+# Set this below the idle timeout of any reverse proxy or middlebox between
+# the client and the relay. Common values: AWS ALB default 60s, Cloudflare
+# ~100s, mobile/CGNAT idle timeouts often 60–300s.
+#ping_interval_seconds = 45
 
 [options]
 # Reject events that have timestamps greater than this many seconds in

--- a/src/config.rs
+++ b/src/config.rs
@@ -42,12 +42,10 @@ pub struct Network {
     pub port: u16,
     pub address: String,
     pub remote_ip_header: Option<String>, // retrieve client IP from this HTTP header if present
-    // The previous example config showed `ping_interval` (no `_seconds` suffix),
-    // which was always silently ignored. The canonical key is this one. We
-    // can't add a serde alias to recover the legacy name: the defaults loaded
-    // by `Config::try_from(default)` already populate `ping_interval_seconds`,
-    // so a user override of `ping_interval` ends up in the same merged map
-    // alongside it, and serde fails the deserialize with `duplicate field`.
+    // Don't add `#[serde(alias = "...")]` here. Defaults loaded via
+    // `Config::try_from(default)` always populate this canonical key in the
+    // merged map, so a user override under any alias collides with it and
+    // serde rejects the deserialize with `duplicate field`.
     pub ping_interval_seconds: u32,
 }
 
@@ -250,8 +248,8 @@ impl Settings {
             settings.verified_users.is_valid(),
             "VerifiedUsers time settings could not be parsed"
         );
-        // tokio::time::interval_at panics on zero duration; surface this as a
-        // ConfigError so the caller in `Settings::new` can format it cleanly.
+        // tokio::time::interval_at panics on zero duration; reject at config
+        // load time with a propagated ConfigError instead of crashing later.
         if settings.network.ping_interval_seconds == 0 {
             return Err(ConfigError::Message(
                 "network.ping_interval_seconds must be > 0".into(),
@@ -320,8 +318,7 @@ impl Default for Settings {
                 // 45s sits below typical client-side middlebox idle timeouts
                 // (corporate proxies, mobile carrier NATs, residential CGNATs)
                 // which often reap quiet upgraded WebSocket connections in the
-                // 60–300s range. Server-side reverse proxies are unaffected at
-                // this value too.
+                // 60–300s range.
                 ping_interval_seconds: 45,
                 address: "0.0.0.0".to_owned(),
                 remote_ip_header: None,
@@ -382,5 +379,82 @@ impl Default for Settings {
                 file_prefix: None,
             },
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn write_temp_config(body: &str) -> std::path::PathBuf {
+        let stamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!(
+            "nostr-relay-config-{}-{}.toml",
+            std::process::id(),
+            stamp
+        ));
+        let mut f = std::fs::File::create(&path).unwrap();
+        f.write_all(body.as_bytes()).unwrap();
+        path
+    }
+
+    #[test]
+    fn rejects_zero_ping_interval() {
+        let path = write_temp_config(
+            r#"
+[network]
+ping_interval_seconds = 0
+"#,
+        );
+        let result = Settings::new(&Some(path.to_string_lossy().to_string()));
+        std::fs::remove_file(&path).ok();
+        match result {
+            Err(ConfigError::Message(msg)) => {
+                assert!(
+                    msg.contains("ping_interval_seconds"),
+                    "error message should mention the offending key, got: {msg}"
+                );
+            }
+            other => panic!("expected ConfigError::Message for zero ping interval, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn legacy_ping_interval_is_silently_ignored() {
+        // This pins the rationale in `Network::ping_interval_seconds`: we don't
+        // (and can't) accept the legacy `ping_interval` key. Any user override
+        // under that name is ignored, the default fills the canonical key, and
+        // load succeeds.
+        let path = write_temp_config(
+            r#"
+[network]
+ping_interval = 30
+"#,
+        );
+        let result = Settings::new(&Some(path.to_string_lossy().to_string()));
+        std::fs::remove_file(&path).ok();
+        let settings = result.expect("legacy key should be ignored, not break loading");
+        assert_eq!(
+            settings.network.ping_interval_seconds, 45,
+            "legacy `ping_interval` must not bleed into the canonical field"
+        );
+    }
+
+    #[test]
+    fn accepts_canonical_ping_interval_seconds() {
+        let path = write_temp_config(
+            r#"
+[network]
+ping_interval_seconds = 30
+"#,
+        );
+        let result = Settings::new(&Some(path.to_string_lossy().to_string()));
+        std::fs::remove_file(&path).ok();
+        let settings = result.expect("valid override should load");
+        assert_eq!(settings.network.ping_interval_seconds, 30);
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -42,6 +42,9 @@ pub struct Network {
     pub port: u16,
     pub address: String,
     pub remote_ip_header: Option<String>, // retrieve client IP from this HTTP header if present
+    // Older configs used `ping_interval`; accept that name too so previously-broken
+    // configs (silently ignored due to the field-name mismatch) start taking effect.
+    #[serde(alias = "ping_interval")]
     pub ping_interval_seconds: u32,
 }
 
@@ -304,7 +307,12 @@ impl Default for Settings {
             },
             network: Network {
                 port: 8080,
-                ping_interval_seconds: 300,
+                // 45s sits below typical client-side middlebox idle timeouts
+                // (corporate proxies, mobile carrier NATs, residential CGNATs)
+                // which often reap quiet upgraded WebSocket connections in the
+                // 60–300s range. Server-side reverse proxies are unaffected at
+                // this value too.
+                ping_interval_seconds: 45,
                 address: "0.0.0.0".to_owned(),
                 remote_ip_header: None,
             },

--- a/src/config.rs
+++ b/src/config.rs
@@ -42,9 +42,12 @@ pub struct Network {
     pub port: u16,
     pub address: String,
     pub remote_ip_header: Option<String>, // retrieve client IP from this HTTP header if present
-    // Older configs used `ping_interval`; accept that name too so previously-broken
-    // configs (silently ignored due to the field-name mismatch) start taking effect.
-    #[serde(alias = "ping_interval")]
+    // The previous example config showed `ping_interval` (no `_seconds` suffix),
+    // which was always silently ignored. The canonical key is this one. We
+    // can't add a serde alias to recover the legacy name: the defaults loaded
+    // by `Config::try_from(default)` already populate `ping_interval_seconds`,
+    // so a user override of `ping_interval` ends up in the same merged map
+    // alongside it, and serde fails the deserialize with `duplicate field`.
     pub ping_interval_seconds: u32,
 }
 
@@ -247,12 +250,13 @@ impl Settings {
             settings.verified_users.is_valid(),
             "VerifiedUsers time settings could not be parsed"
         );
-        // tokio::time::interval_at panics on zero duration; reject early with a
-        // clear message instead of crashing the server after deploy.
-        assert!(
-            settings.network.ping_interval_seconds > 0,
-            "network.ping_interval_seconds must be > 0"
-        );
+        // tokio::time::interval_at panics on zero duration; surface this as a
+        // ConfigError so the caller in `Settings::new` can format it cleanly.
+        if settings.network.ping_interval_seconds == 0 {
+            return Err(ConfigError::Message(
+                "network.ping_interval_seconds must be > 0".into(),
+            ));
+        }
         // initialize durations for verified users
         settings.verified_users.init();
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -247,6 +247,12 @@ impl Settings {
             settings.verified_users.is_valid(),
             "VerifiedUsers time settings could not be parsed"
         );
+        // tokio::time::interval_at panics on zero duration; reject early with a
+        // clear message instead of crashing the server after deploy.
+        assert!(
+            settings.network.ping_interval_seconds > 0,
+            "network.ping_interval_seconds must be > 0"
+        );
         // initialize durations for verified users
         settings.verified_users.init();
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -439,7 +439,8 @@ ping_interval = 30
         std::fs::remove_file(&path).ok();
         let settings = result.expect("legacy key should be ignored, not break loading");
         assert_eq!(
-            settings.network.ping_interval_seconds, 45,
+            settings.network.ping_interval_seconds,
+            Settings::default().network.ping_interval_seconds,
             "legacy `ping_interval` must not bleed into the canonical field"
         );
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1315,9 +1315,10 @@ async fn nostr_server(
     // ping interval — defaults to 45s, see config.rs for rationale.
     let default_ping_dur = Duration::from_secs(settings.network.ping_interval_seconds.into());
 
-    // Disconnect a client that hasn't said anything for ~4 ping intervals.
-    // Floor at 5 minutes so very short ping intervals don't reap clients that
-    // briefly stop responding (e.g. mobile suspending the tab).
+    // Disconnect a client that hasn't said anything for a while. Target is
+    // ~4 ping intervals, but floored at 5 minutes so brief pauses (e.g. mobile
+    // suspending the tab) don't trigger reaps at short ping intervals. With
+    // the 45s default the floor wins, giving ~6.7 ping intervals before reap.
     let max_quiet_time = std::cmp::max(Duration::from_secs(300), default_ping_dur * 4);
 
     let start = tokio::time::Instant::now() + default_ping_dur;

--- a/src/server.rs
+++ b/src/server.rs
@@ -1312,13 +1312,11 @@ async fn nostr_server(
     // last time this client sent data (message, ping, etc.)
     let mut last_message_time = Instant::now();
 
-    // ping interval — defaults to 45s, see config.rs for rationale.
     let default_ping_dur = Duration::from_secs(settings.network.ping_interval_seconds.into());
 
     // Disconnect a client that hasn't said anything for a while. Target is
-    // ~4 ping intervals, but floored at 5 minutes so brief pauses (e.g. mobile
-    // suspending the tab) don't trigger reaps at short ping intervals. With
-    // the 45s default the floor wins, giving ~6.7 ping intervals before reap.
+    // ~4 ping intervals, floored at 5 minutes so brief pauses (e.g. mobile
+    // suspending the tab) don't trigger reaps at short ping intervals.
     let max_quiet_time = std::cmp::max(Duration::from_secs(300), default_ping_dur * 4);
 
     let start = tokio::time::Instant::now() + default_ping_dur;

--- a/src/server.rs
+++ b/src/server.rs
@@ -1312,11 +1312,13 @@ async fn nostr_server(
     // last time this client sent data (message, ping, etc.)
     let mut last_message_time = Instant::now();
 
-    // ping interval (every 5 minutes)
+    // ping interval — defaults to 45s, see config.rs for rationale.
     let default_ping_dur = Duration::from_secs(settings.network.ping_interval_seconds.into());
 
-    // disconnect after 20 minutes without a ping response or event.
-    let max_quiet_time = Duration::from_secs(60 * 20);
+    // Disconnect a client that hasn't said anything for ~4 ping intervals.
+    // Floor at 5 minutes so very short ping intervals don't reap clients that
+    // briefly stop responding (e.g. mobile suspending the tab).
+    let max_quiet_time = std::cmp::max(Duration::from_secs(300), default_ping_dur * 4);
 
     let start = tokio::time::Instant::now() + default_ping_dur;
     let mut ping_interval = tokio::time::interval_at(start, default_ping_dur);


### PR DESCRIPTION
Closes #3, #5, #6.

## Summary

- Default `ping_interval_seconds` 300 → **45** (`src/config.rs`).
- `max_quiet_time` no longer hardcoded to 20 min — now `max(5 min, ping * 4)` (`src/server.rs`).
- `config.toml` example fixed to canonical `ping_interval_seconds` (was `ping_interval`, silently ignored). Migration note added so operators who copied the legacy example know to rename the key.
- Reject `ping_interval_seconds = 0` at config load with a `ConfigError` (would have panicked in `tokio::time::interval_at` on first tick).

## Why

300s ping is longer than the idle timeout of typical middleboxes between browser and relay — corporate proxies, mobile carrier NATs, residential CGNATs commonly reap upgraded-WebSocket flows in the 60–300s window. When the middlebox kills the TCP connection silently, neither end learns about it until the relay's next ping fails, which today can take up to 5 minutes (plus up to ~15 min of TCP retransmits if the dead path swallows writes instead of RST'ing). User-visible symptom: "WSS dropped, can't reconnect for ~minute."

Production ALB idle timeout is set to 3600s (per @MastaP's check in #3), so the ALB isn't the chokepoint here — but the ~2% baseline of `nostr_disconnects_total{reason="send_error"}` is consistent with client-side middlebox timeouts.

## Note on legacy `ping_interval` key

An earlier revision of this branch tried `#[serde(alias = "ping_interval")]` to make legacy configs take effect. **Empirically verified this breaks startup**: `Config::try_from(default)` always populates `ping_interval_seconds` in the merged map, so a user override of `ping_interval` collides with it and serde rejects the deserialize with `duplicate field`. The alias is now removed; the legacy key remains silently ignored exactly as before this PR. The test `legacy_ping_interval_is_silently_ignored` pins this behavior.

**Operator action**: any prod `config.toml` using `ping_interval = N` (silently ignored before, still ignored now) needs to be renamed to `ping_interval_seconds = N` if the operator wants a non-default value. With no rename, the new default of 45s applies — which is the desired behavior in most cases, but worth a one-line config audit before deploy.

## Test plan

- [ ] `cargo check` clean
- [ ] `cargo clippy` no new warnings (only pre-existing `result_large_err` / `assertions_on_constants` in `subscription.rs`/`error.rs`)
- [ ] `cargo test --all` passes — includes 3 new unit tests in `src/config.rs`:
  - `rejects_zero_ping_interval` — validates the new `ConfigError::Message` path
  - `legacy_ping_interval_is_silently_ignored` — pins legacy-key behavior
  - `accepts_canonical_ping_interval_seconds` — positive case
- [ ] Sanity-check after deploy: `rate(nostr_disconnects_total{reason="send_error"}[5m])` over 24–48h. If it stays flat, the baseline was client-side noise (browser crashes, mobile suspension) and the ping interval can be revisited.
- [ ] Audit any prod `config.toml` for the legacy `ping_interval` key. If present and intentional, rename to `ping_interval_seconds` before deploy.

## Out of scope

- #4 (write-timeout wrapper around `ws_stream.send`) — separate PR; the architectural fix is bigger and worth landing on its own.
- #7 (broadcast-lag counter) and #8 (`thread::sleep` in `db_writer`) — also separate.