### PR TITLE
feat: expose nostr_broadcast_lagged_total counter

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -43,6 +43,7 @@ Counters for raw command frames received from clients.
 | `nostr_events_ephemeral_broadcast_by_kind_total` | counter | `kind` | Ephemeral events broadcast to subscribers without being persisted, by kind. |
 | `nostr_events_rejected_total` | counter | `reason` | Events rejected before persistence. Reasons: `expired`, `future_dated`, `kind_blacklist`, `kind_allowlist`, `pubkey_not_whitelisted`, `not_admitted`, `insufficient_balance`, `pubkey_not_registered`, `admission_check_error`, `nip05_invalid`, `nip05_missing`, `nip05_error`, `grpc_denied`, `duplicate`, `write_error` |
 | `nostr_events_sent_total` | counter | `source` | Events sent to subscribers. `source` = `db` (historical query result) or `realtime` (broadcast match) |
+| `nostr_broadcast_lagged_total` | counter | — | Broadcast events dropped because a per-connection receiver fell behind (the receiver's slot in the broadcast channel overflowed `broadcast_buffer`). Spikes here indicate slow consumers — usually backpressure from a stuck `ws_stream.send`. |
 
 ### Latency histograms
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -14,7 +14,7 @@ These are updated synchronously as traffic hits the relay.
 |---|---|---|---|
 | `nostr_connections_total` | counter | — | New WebSocket connections accepted (cumulative) |
 | `nostr_connections_active` | gauge | — | Currently-open WebSocket connections |
-| `nostr_disconnects_total` | counter | `reason` | Disconnects, by cause: `shutdown`, `timeout`, `send_error`, `normal`, `error` |
+| `nostr_disconnects_total` | counter | `reason` | Disconnects, by cause: `shutdown`, `timeout`, `send_error`, `normal`, `error`, `broadcast_closed`. `broadcast_closed` means the broadcast sender went away (db_writer panic / relay teardown) and the connection closed because no more events would arrive. |
 
 ### Subscription lifecycle
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -1419,7 +1419,7 @@ async fn nostr_server(
             bcast_result = bcast_rx.recv() => {
                 let global_event = match bcast_result {
                     Ok(ev) => ev,
-                    Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                    Err(broadcast::error::RecvError::Lagged(n)) => {
                         // Slow consumer: broadcast channel dropped n events for
                         // this receiver. Surface it as a counter so we can spot
                         // chronic lag in production instead of losing events
@@ -1427,10 +1427,13 @@ async fn nostr_server(
                         metrics.broadcast_lagged.inc_by(n);
                         continue;
                     }
-                    Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                    Err(broadcast::error::RecvError::Closed) => {
                         // Broadcast sender is gone (relay shutdown / db_writer
                         // exit). No more events will arrive on this channel,
                         // so close the connection rather than spinning forever.
+                        // Tag the disconnect so this case is visible in
+                        // dashboards alongside other fatal exits.
+                        metrics.disconnects.with_label_values(&["broadcast_closed"]).inc();
                         break;
                     }
                 };

--- a/src/server.rs
+++ b/src/server.rs
@@ -729,6 +729,11 @@ fn create_metrics() -> (Registry, NostrMetrics) {
     .unwrap();
     let connections =
         IntCounter::with_opts(Opts::new("nostr_connections_total", "New connections")).unwrap();
+    let broadcast_lagged = IntCounter::with_opts(Opts::new(
+        "nostr_broadcast_lagged_total",
+        "Broadcast events dropped because a per-connection receiver fell behind",
+    ))
+    .unwrap();
     let db_connections = IntGauge::with_opts(Opts::new(
         "nostr_db_connections",
         "Active database connections",
@@ -821,6 +826,7 @@ fn create_metrics() -> (Registry, NostrMetrics) {
     registry.register(Box::new(write_events.clone())).unwrap();
     registry.register(Box::new(sent_events.clone())).unwrap();
     registry.register(Box::new(connections.clone())).unwrap();
+    registry.register(Box::new(broadcast_lagged.clone())).unwrap();
     registry.register(Box::new(db_connections.clone())).unwrap();
     registry.register(Box::new(query_aborts.clone())).unwrap();
     registry.register(Box::new(cmd_req.clone())).unwrap();
@@ -844,6 +850,7 @@ fn create_metrics() -> (Registry, NostrMetrics) {
         write_events,
         sent_events,
         connections,
+        broadcast_lagged,
         db_connections,
         disconnects,
         query_aborts,
@@ -1409,8 +1416,24 @@ async fn nostr_server(
                     }
                 }
             },
-            // TODO: consider logging the LaggedRecv error
-            Ok(global_event) = bcast_rx.recv() => {
+            bcast_result = bcast_rx.recv() => {
+                let global_event = match bcast_result {
+                    Ok(ev) => ev,
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                        // Slow consumer: broadcast channel dropped n events for
+                        // this receiver. Surface it as a counter so we can spot
+                        // chronic lag in production instead of losing events
+                        // silently.
+                        metrics.broadcast_lagged.inc_by(n);
+                        continue;
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                        // Broadcast sender is gone (relay shutdown / db_writer
+                        // exit). No more events will arrive on this channel,
+                        // so close the connection rather than spinning forever.
+                        break;
+                    }
+                };
                 let mut should_disconnect = false;
                 // an event has been broadcast to all clients
                 // first check if there is a subscription for this event.
@@ -1782,6 +1805,7 @@ pub struct NostrMetrics {
     pub write_events: Histogram,     // response time of event writes
     pub sent_events: IntCounterVec,  // count of events sent to clients
     pub connections: IntCounter,     // count of websocket connections
+    pub broadcast_lagged: IntCounter, // broadcast events dropped because a receiver fell behind
     pub disconnects: IntCounterVec,  // client disconnects
     pub query_aborts: IntCounterVec, // count of queries aborted by server
     pub cmd_req: IntCounter,         // count of REQ commands received


### PR DESCRIPTION
Closes #7.

## Summary

Add `nostr_broadcast_lagged_total` (counter, unlabelled) so chronic slow-consumer lag in production becomes visible. Resolves the `// TODO: consider logging the LaggedRecv error` that was sitting on the same arm.

## What changes

- `bcast_rx.recv()` arm now matches the `Result` explicitly:
  - `Ok(ev)` — unchanged path.
  - `Err(Lagged(n))` — `metrics.broadcast_lagged.inc_by(n)` (counts actual dropped events, not just "lagged occurrences"), then `continue`.
  - `Err(Closed)` — `break`. Pre-change the `Ok(...)` pattern silently dropped this case, leaving the connection task spinning on a permanently-dead receiver. Only happens at full relay shutdown or if `db_writer` panics; the shutdown arm of the select handles the former, but breaking on Closed defends against the latter.
- Counter is **unlabelled** — adding `cid` or per-conn labels would blow Prometheus cardinality with no operational gain.

## Why

Until now the `Ok(...)` arm pattern silently swallowed both `Lagged` and `Closed`. Slow consumers (events vanishing for some subscribers) had zero observability — the only signal was "users complain about missing events," which is too lossy.

## Out of scope

Addressing what *causes* `Lagged` is the architectural fix in #4 (slow `ws_stream.send` stalling the connection's broadcast receive). This PR just makes the symptom visible.

## Test plan

- [ ] `cargo check` clean
- [ ] `cargo clippy` no new warnings
- [ ] `cargo test --all` passes (102 tests). No new tests — triggering `Lagged` requires a multi-task setup that overproduces against a held receiver, and writing a deterministic reproducer felt out of proportion to a counter increment.
- [ ] Post-deploy: scrape `/metrics` once, confirm the new series shows up at value 0.