### PR TITLE
feat: bound WebSocket sends with WS_WRITE_TIMEOUT (30s)

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -146,6 +146,12 @@ reject_future_seconds = 1800
 # Maximum WebSocket frame size in bytes.  Defaults to 128 KB.
 #max_ws_frame_bytes = 131072
 
+# Hard cap on a single WebSocket send, in seconds.  Default is 30, which
+# is generous for the 128 KB default message size.  If you raise
+# `max_ws_message_bytes` to 1 MiB or more, bump this to ~60–90 to avoid
+# timing out legitimate slow consumers (mobile / CGNAT clients).
+#ws_write_timeout_seconds = 30
+
 # Broadcast buffer size, in number of events.  This prevents slow
 # readers from consuming memory.
 #broadcast_buffer = 16384

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -14,7 +14,7 @@ These are updated synchronously as traffic hits the relay.
 |---|---|---|---|
 | `nostr_connections_total` | counter | — | New WebSocket connections accepted (cumulative) |
 | `nostr_connections_active` | gauge | — | Currently-open WebSocket connections |
-| `nostr_disconnects_total` | counter | `reason` | Disconnects, by cause: `shutdown`, `timeout`, `send_error`, `normal`, `error`, `broadcast_closed`. `broadcast_closed` means the broadcast sender went away (db_writer panic / relay teardown) and the connection closed because no more events would arrive. |
+| `nostr_disconnects_total` | counter | `reason` | Disconnects, by cause: `shutdown`, `timeout`, `send_error`, `write_timeout`, `normal`, `error`, `broadcast_closed`. `write_timeout` means a `ws_stream.send` exceeded the 30s write cap (peer didn't drain — usually a dead-but-not-RST'd connection that would otherwise stall the task for the full TCP retransmit window). `broadcast_closed` means the broadcast sender went away (db_writer panic / relay teardown) and the connection closed because no more events would arrive. |
 
 ### Subscription lifecycle
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -14,7 +14,7 @@ These are updated synchronously as traffic hits the relay.
 |---|---|---|---|
 | `nostr_connections_total` | counter | — | New WebSocket connections accepted (cumulative) |
 | `nostr_connections_active` | gauge | — | Currently-open WebSocket connections |
-| `nostr_disconnects_total` | counter | `reason` | Disconnects, by cause: `shutdown`, `timeout`, `send_error`, `write_timeout`, `normal`, `error`, `broadcast_closed`. `write_timeout` means a `ws_stream.send` exceeded the 30s write cap (peer didn't drain — usually a dead-but-not-RST'd connection that would otherwise stall the task for the full TCP retransmit window). `broadcast_closed` means the broadcast sender went away (db_writer panic / relay teardown) and the connection closed because no more events would arrive. |
+| `nostr_disconnects_total` | counter | `reason` | Disconnects, by cause: `shutdown`, `timeout`, `send_error`, `write_timeout`, `normal`, `error`, `broadcast_closed`. `write_timeout` means a `ws_stream.send` exceeded the configured `limits.ws_write_timeout_seconds` cap (default 30s) — peer didn't drain, usually a dead-but-not-RST'd connection that would otherwise stall the task for the full TCP retransmit window. `broadcast_closed` means the broadcast sender went away (db_writer panic / relay teardown) and the connection closed because no more events would arrive. |
 
 ### Subscription lifecycle
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -75,6 +75,7 @@ pub struct Limits {
     pub max_event_bytes: Option<usize>, // Maximum size of an EVENT message
     pub max_ws_message_bytes: Option<usize>,
     pub max_ws_frame_bytes: Option<usize>,
+    pub ws_write_timeout_seconds: u32, // hard cap on a single ws_stream.send; prevents stuck-write zombies pinning the connection task
     pub broadcast_buffer: usize, // events to buffer for subscribers (prevents slow readers from consuming memory)
     pub event_persist_buffer: usize, // events to buffer for database commits (block senders if database writes are too slow)
     pub event_kind_blacklist: Option<Vec<u64>>,
@@ -255,6 +256,14 @@ impl Settings {
                 "network.ping_interval_seconds must be > 0".into(),
             ));
         }
+        // Same constraint for ws_write_timeout_seconds — `tokio::time::timeout`
+        // with Duration::ZERO is technically legal (always elapses immediately)
+        // but means every send disconnects, which is never the user's intent.
+        if settings.limits.ws_write_timeout_seconds == 0 {
+            return Err(ConfigError::Message(
+                "limits.ws_write_timeout_seconds must be > 0".into(),
+            ));
+        }
         // initialize durations for verified users
         settings.verified_users.init();
 
@@ -331,6 +340,12 @@ impl Default for Settings {
                 max_event_bytes: Some(2 << 17),      // 128K
                 max_ws_message_bytes: Some(2 << 17), // 128K
                 max_ws_frame_bytes: Some(2 << 17),   // 128K
+                // Bound on a single WebSocket send. 30s is generous for the
+                // 128K default message size (covers slow mobile/CGNAT clients
+                // at ~5KB/s and up). If you've raised `max_ws_message_bytes`
+                // to 1 MiB, bump this to ~60–90s to avoid timing out
+                // legitimate slow consumers.
+                ws_write_timeout_seconds: 30,
                 broadcast_buffer: 16384,
                 event_persist_buffer: 4096,
                 event_kind_blacklist: None,
@@ -457,5 +472,26 @@ ping_interval_seconds = 30
         std::fs::remove_file(&path).ok();
         let settings = result.expect("valid override should load");
         assert_eq!(settings.network.ping_interval_seconds, 30);
+    }
+
+    #[test]
+    fn rejects_zero_ws_write_timeout() {
+        let path = write_temp_config(
+            r#"
+[limits]
+ws_write_timeout_seconds = 0
+"#,
+        );
+        let result = Settings::new(&Some(path.to_string_lossy().to_string()));
+        std::fs::remove_file(&path).ok();
+        match result {
+            Err(ConfigError::Message(msg)) => {
+                assert!(
+                    msg.contains("ws_write_timeout_seconds"),
+                    "error message should mention the offending key, got: {msg}"
+                );
+            }
+            other => panic!("expected ConfigError::Message for zero ws write timeout, got {other:?}"),
+        }
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1262,7 +1262,13 @@ async fn ws_send(
 ) -> Result<(), &'static str> {
     match tokio::time::timeout(WS_WRITE_TIMEOUT, ws.send(msg)).await {
         Ok(Ok(())) => Ok(()),
-        Ok(Err(_)) => Err("send_error"),
+        Ok(Err(e)) => {
+            // Preserve the underlying WsError for diagnosis — only the metric
+            // label propagates out of this helper, but the cause is useful
+            // when chasing why a peer's send failed.
+            debug!("ws send error: {:?}", e);
+            Err("send_error")
+        }
         Err(_) => Err("write_timeout"),
     }
 }
@@ -1403,14 +1409,14 @@ async fn nostr_server(
                 }
                 // Send a ping
                 if let Err(reason) = ws_send(&mut ws_stream, Message::Ping(Vec::new())).await {
-                    debug!("failed to send ping, closing connection (cid: {})", cid);
+                    debug!("failed to send ping (reason: {}), closing connection (cid: {})", reason, cid);
                     metrics.disconnects.with_label_values(&[reason]).inc();
                     break;
                 }
             },
             Some(notice_msg) = notice_rx.recv() => {
                 if let Err(reason) = ws_send(&mut ws_stream, make_notice_message(&notice_msg)).await {
-                    debug!("failed to send notice, closing connection (cid: {})", cid);
+                    debug!("failed to send notice (reason: {}), closing connection (cid: {})", reason, cid);
                     metrics.disconnects.with_label_values(&[reason]).inc();
                     break;
                 }
@@ -1421,7 +1427,7 @@ async fn nostr_server(
                 if query_result.event == "EOSE" {
                     let send_str = format!("[\"EOSE\",\"{subesc}\"]");
                     if let Err(reason) = ws_send(&mut ws_stream, Message::Text(send_str)).await {
-                        debug!("failed to send message, closing connection (cid: {})", cid);
+                        debug!("failed to send message (reason: {}), closing connection (cid: {})", reason, cid);
                         metrics.disconnects.with_label_values(&[reason]).inc();
                         break;
                     }
@@ -1431,7 +1437,7 @@ async fn nostr_server(
                     // send a result
                     let send_str = format!("[\"EVENT\",\"{}\",{}]", subesc, &query_result.event);
                     if let Err(reason) = ws_send(&mut ws_stream, Message::Text(send_str)).await {
-                        debug!("failed to send message, closing connection (cid: {})", cid);
+                        debug!("failed to send message (reason: {}), closing connection (cid: {})", reason, cid);
                         metrics.disconnects.with_label_values(&[reason]).inc();
                         break;
                     }
@@ -1476,7 +1482,7 @@ async fn nostr_server(
                             let subesc = s.replace('"', "");
                             metrics.sent_events.with_label_values(&["realtime"]).inc();
                             if let Err(reason) = ws_send(&mut ws_stream, Message::Text(format!("[\"EVENT\",\"{subesc}\",{event_str}]"))).await {
-                                debug!("failed to send message, closing connection (cid: {})", cid);
+                                debug!("failed to send message (reason: {}), closing connection (cid: {})", reason, cid);
                                 metrics.disconnects.with_label_values(&[reason]).inc();
                                 should_disconnect = true;
                                 break;
@@ -1504,7 +1510,7 @@ async fn nostr_server(
                             &mut ws_stream,
                             make_notice_message(&Notice::message("binary messages are not accepted".into())),
                         ).await {
-                            debug!("failed to send notice, closing connection (cid: {})", cid);
+                            debug!("failed to send notice (reason: {}), closing connection (cid: {})", reason, cid);
                             metrics.disconnects.with_label_values(&[reason]).inc();
                             break;
                         }
@@ -1520,7 +1526,7 @@ async fn nostr_server(
                             &mut ws_stream,
                             make_notice_message(&Notice::message(format!("message too large ({size} > {max_size})"))),
                         ).await {
-                            debug!("failed to send notice, closing connection (cid: {})", cid);
+                            debug!("failed to send notice (reason: {}), closing connection (cid: {})", reason, cid);
                             metrics.disconnects.with_label_values(&[reason]).inc();
                             break;
                         }
@@ -1570,7 +1576,7 @@ async fn nostr_server(
                                     metrics.events_rejected.with_label_values(&["expired"]).inc();
                                     let notice = Notice::invalid(e.id, "The event has already expired");
                                     if let Err(reason) = ws_send(&mut ws_stream, make_notice_message(&notice)).await {
-                                        debug!("failed to send notice, closing connection (cid: {})", cid);
+                                        debug!("failed to send notice (reason: {}), closing connection (cid: {})", reason, cid);
                                         metrics.disconnects.with_label_values(&[reason]).inc();
                                         break;
                                     }
@@ -1594,7 +1600,7 @@ async fn nostr_server(
                                         let msg = format!("The event created_at field is out of the acceptable range (+{fut_sec}sec) for this relay.");
                                         let notice = Notice::invalid(e.id, &msg);
                                         if let Err(reason) = ws_send(&mut ws_stream, make_notice_message(&notice)).await {
-                                            debug!("failed to send notice, closing connection (cid: {})", cid);
+                                            debug!("failed to send notice (reason: {}), closing connection (cid: {})", reason, cid);
                                             metrics.disconnects.with_label_values(&[reason]).inc();
                                             break;
 
@@ -1621,7 +1627,7 @@ async fn nostr_server(
                                                     info!("client is authenticated: (cid: {}, pubkey: {:?})", cid, pubkey);
                                                     // Send OK message to confirm successful authentication (NIP-42)
                                                     if let Err(reason) = ws_send(&mut ws_stream, make_notice_message(&Notice::saved(event.id))).await {
-                                                        debug!("failed to send notice, closing connection (cid: {})", cid);
+                                                        debug!("failed to send notice (reason: {}), closing connection (cid: {})", reason, cid);
                                                         metrics.disconnects.with_label_values(&[reason]).inc();
                                                         break;
                                                     }
@@ -1629,7 +1635,7 @@ async fn nostr_server(
                                                 Err(e) => {
                                                     info!("authentication error: {} (cid: {})", e, cid);
                                                     if let Err(reason) = ws_send(&mut ws_stream, make_notice_message(&Notice::restricted(event.id, format!("authentication error: {e}").as_str()))).await {
-                                                        debug!("failed to send notice, closing connection (cid: {})", cid);
+                                                        debug!("failed to send notice (reason: {}), closing connection (cid: {})", reason, cid);
                                                         metrics.disconnects.with_label_values(&[reason]).inc();
                                                         break;
                                                     }
@@ -1641,7 +1647,7 @@ async fn nostr_server(
                                     let e = CommandUnknownError;
                                     info!("client sent an invalid event (cid: {})", cid);
                                     if let Err(reason) = ws_send(&mut ws_stream, make_notice_message(&Notice::invalid(evid, &format!("{e}")))).await {
-                                        debug!("failed to send notice, closing connection (cid: {})", cid);
+                                        debug!("failed to send notice (reason: {}), closing connection (cid: {})", reason, cid);
                                         metrics.disconnects.with_label_values(&[reason]).inc();
                                         break;
                                     }
@@ -1651,7 +1657,7 @@ async fn nostr_server(
                                 metrics.cmd_event.inc();
                                 info!("client sent an invalid event (cid: {})", cid);
                                 if let Err(reason) = ws_send(&mut ws_stream, make_notice_message(&Notice::invalid(evid, &format!("{e}")))).await {
-                                    debug!("failed to send notice, closing connection (cid: {})", cid);
+                                    debug!("failed to send notice (reason: {}), closing connection (cid: {})", reason, cid);
                                     metrics.disconnects.with_label_values(&[reason]).inc();
                                     break;
                                 }
@@ -1676,7 +1682,7 @@ async fn nostr_server(
                             if settings.limits.limit_scrapers && s.is_scraper() {
                                 info!("subscription was scraper, ignoring (cid: {}, sub: {:?})", cid, s.id);
                                 if let Err(reason) = ws_send(&mut ws_stream, Message::Text(format!("[\"EOSE\",\"{}\"]", s.id))).await {
-                                    debug!("failed to send message, closing connection (cid: {})", cid);
+                                    debug!("failed to send message (reason: {}), closing connection (cid: {})", reason, cid);
                                     metrics.disconnects.with_label_values(&[reason]).inc();
                                     break;
                                 }
@@ -1708,7 +1714,7 @@ async fn nostr_server(
                                 Err(e) => {
                                     info!("Subscription error: {} (cid: {}, sub: {:?})", e, cid, s.id);
                                     if let Err(reason) = ws_send(&mut ws_stream, make_notice_message(&Notice::message(format!("Subscription error: {e}")))).await {
-                                        debug!("failed to send notice, closing connection (cid: {})", cid);
+                                        debug!("failed to send notice (reason: {}), closing connection (cid: {})", reason, cid);
                                         metrics.disconnects.with_label_values(&[reason]).inc();
                                         break;
 
@@ -1738,7 +1744,7 @@ async fn nostr_server(
                         } else {
                             info!("invalid command ignored");
                             if let Err(reason) = ws_send(&mut ws_stream, make_notice_message(&Notice::message("could not parse command".into()))).await {
-                                debug!("failed to send notice, closing connection (cid: {})", cid);
+                                debug!("failed to send notice (reason: {}), closing connection (cid: {})", reason, cid);
                                 metrics.disconnects.with_label_values(&[reason]).inc();
                                 break;
                             }
@@ -1751,7 +1757,7 @@ async fn nostr_server(
                     Err(Error::EventMaxLengthError(s)) => {
                         info!("client sent command larger ({} bytes) than max size (cid: {})", s, cid);
                         if let Err(reason) = ws_send(&mut ws_stream, make_notice_message(&Notice::message("event exceeded max size".into()))).await {
-                            debug!("failed to send notice, closing connection (cid: {})", cid);
+                            debug!("failed to send notice (reason: {}), closing connection (cid: {})", reason, cid);
                             metrics.disconnects.with_label_values(&[reason]).inc();
                             break;
                         }
@@ -1759,7 +1765,7 @@ async fn nostr_server(
                     Err(Error::ProtoParseError) => {
                         info!("client sent command that could not be parsed (cid: {})", cid);
                         if let Err(reason) = ws_send(&mut ws_stream, make_notice_message(&Notice::message("could not parse command".into()))).await {
-                            debug!("failed to send notice, closing connection (cid: {})", cid);
+                            debug!("failed to send notice (reason: {}), closing connection (cid: {})", reason, cid);
                             metrics.disconnects.with_label_values(&[reason]).inc();
                             break;
                         }

--- a/src/server.rs
+++ b/src/server.rs
@@ -1383,11 +1383,16 @@ async fn nostr_server(
     if settings.authorization.nip42_auth {
         conn.generate_auth_challenge();
         if let Some(challenge) = conn.auth_challenge() {
-            let _ = ws_send(
+            if let Err(reason) = ws_send(
                 &mut ws_stream,
                 make_notice_message(&Notice::AuthChallenge(challenge.to_string())),
             )
-            .await;
+            .await
+            {
+                debug!("failed to send AUTH challenge (reason: {}), closing connection (cid: {})", reason, cid);
+                metrics.disconnects.with_label_values(&[reason]).inc();
+                return;
+            }
         }
     }
 
@@ -1771,7 +1776,7 @@ async fn nostr_server(
                         }
                     },
                     Err(e) => {
-                        info!("got non-fatal error from client (cid: {}, error: {:?}", cid, e);
+                        info!("got non-fatal error from client (cid: {}, error: {:?})", cid, e);
                     },
                 }
             },

--- a/src/server.rs
+++ b/src/server.rs
@@ -1245,22 +1245,21 @@ fn make_notice_message(notice: &Notice) -> Message {
     Message::text(json.to_string())
 }
 
-/// Hard cap on how long a single WebSocket send can take. Without this, a
-/// dead-but-not-RST'd peer can keep `ws_stream.send().await` blocked for as
-/// long as TCP retransmits run — `tcp_retries2 * exponential backoff` ≈ 15
-/// minutes on Linux defaults — pinning the connection task and starving
-/// the ping/shutdown arms of the select loop the whole time.
-const WS_WRITE_TIMEOUT: Duration = Duration::from_secs(30);
-
-/// Send a message on the WebSocket sink with a write-side timeout. On
-/// failure, returns the disconnect-reason label for the metrics counter:
+/// Send a message on the WebSocket sink with a write-side timeout. Without
+/// the cap, a dead-but-not-RST'd peer can keep `ws_stream.send().await`
+/// blocked for as long as TCP retransmits run — `tcp_retries2 * exponential
+/// backoff` ≈ 15 minutes on Linux defaults — pinning the connection task
+/// and starving the ping/shutdown arms of the select loop the whole time.
+///
+/// On failure, returns the disconnect-reason label for the metrics counter:
 /// `"send_error"` (sink errored) or `"write_timeout"` (peer didn't drain
-/// within `WS_WRITE_TIMEOUT`).
+/// within `timeout`).
 async fn ws_send(
     ws: &mut WebSocketStream<Upgraded>,
     msg: Message,
+    timeout: Duration,
 ) -> Result<(), &'static str> {
-    match tokio::time::timeout(WS_WRITE_TIMEOUT, ws.send(msg)).await {
+    match tokio::time::timeout(timeout, ws.send(msg)).await {
         Ok(Ok(())) => Ok(()),
         Ok(Err(e)) => {
             // Preserve the underlying WsError for diagnosis — only the metric
@@ -1325,6 +1324,9 @@ async fn nostr_server(
     let mut sub_lim_opt = None;
     // 100ms jitter when the rate limiter returns
     let jitter = Jitter::up_to(Duration::from_millis(100));
+    // Per-send write timeout (validated > 0 at config load).
+    let ws_write_timeout =
+        Duration::from_secs(settings.limits.ws_write_timeout_seconds.into());
     let sub_per_min_setting = settings.limits.subscriptions_per_min;
     if let Some(sub_per_min) = sub_per_min_setting {
         if sub_per_min > 0 {
@@ -1386,6 +1388,7 @@ async fn nostr_server(
             if let Err(reason) = ws_send(
                 &mut ws_stream,
                 make_notice_message(&Notice::AuthChallenge(challenge.to_string())),
+                ws_write_timeout,
             )
             .await
             {
@@ -1413,14 +1416,14 @@ async fn nostr_server(
                     break;
                 }
                 // Send a ping
-                if let Err(reason) = ws_send(&mut ws_stream, Message::Ping(Vec::new())).await {
+                if let Err(reason) = ws_send(&mut ws_stream, Message::Ping(Vec::new()), ws_write_timeout).await {
                     debug!("failed to send ping (reason: {}), closing connection (cid: {})", reason, cid);
                     metrics.disconnects.with_label_values(&[reason]).inc();
                     break;
                 }
             },
             Some(notice_msg) = notice_rx.recv() => {
-                if let Err(reason) = ws_send(&mut ws_stream, make_notice_message(&notice_msg)).await {
+                if let Err(reason) = ws_send(&mut ws_stream, make_notice_message(&notice_msg), ws_write_timeout).await {
                     debug!("failed to send notice (reason: {}), closing connection (cid: {})", reason, cid);
                     metrics.disconnects.with_label_values(&[reason]).inc();
                     break;
@@ -1431,7 +1434,7 @@ async fn nostr_server(
                 let subesc = query_result.sub_id.replace('"', "");
                 if query_result.event == "EOSE" {
                     let send_str = format!("[\"EOSE\",\"{subesc}\"]");
-                    if let Err(reason) = ws_send(&mut ws_stream, Message::Text(send_str)).await {
+                    if let Err(reason) = ws_send(&mut ws_stream, Message::Text(send_str), ws_write_timeout).await {
                         debug!("failed to send message (reason: {}), closing connection (cid: {})", reason, cid);
                         metrics.disconnects.with_label_values(&[reason]).inc();
                         break;
@@ -1441,7 +1444,7 @@ async fn nostr_server(
                     client_received_event_count += 1;
                     // send a result
                     let send_str = format!("[\"EVENT\",\"{}\",{}]", subesc, &query_result.event);
-                    if let Err(reason) = ws_send(&mut ws_stream, Message::Text(send_str)).await {
+                    if let Err(reason) = ws_send(&mut ws_stream, Message::Text(send_str), ws_write_timeout).await {
                         debug!("failed to send message (reason: {}), closing connection (cid: {})", reason, cid);
                         metrics.disconnects.with_label_values(&[reason]).inc();
                         break;
@@ -1486,7 +1489,7 @@ async fn nostr_server(
                                global_event.get_event_id_prefix());
                             let subesc = s.replace('"', "");
                             metrics.sent_events.with_label_values(&["realtime"]).inc();
-                            if let Err(reason) = ws_send(&mut ws_stream, Message::Text(format!("[\"EVENT\",\"{subesc}\",{event_str}]"))).await {
+                            if let Err(reason) = ws_send(&mut ws_stream, Message::Text(format!("[\"EVENT\",\"{subesc}\",{event_str}]")), ws_write_timeout).await {
                                 debug!("failed to send message (reason: {}), closing connection (cid: {})", reason, cid);
                                 metrics.disconnects.with_label_values(&[reason]).inc();
                                 should_disconnect = true;
@@ -1514,6 +1517,7 @@ async fn nostr_server(
                         if let Err(reason) = ws_send(
                             &mut ws_stream,
                             make_notice_message(&Notice::message("binary messages are not accepted".into())),
+                            ws_write_timeout,
                         ).await {
                             debug!("failed to send notice (reason: {}), closing connection (cid: {})", reason, cid);
                             metrics.disconnects.with_label_values(&[reason]).inc();
@@ -1530,6 +1534,7 @@ async fn nostr_server(
                         if let Err(reason) = ws_send(
                             &mut ws_stream,
                             make_notice_message(&Notice::message(format!("message too large ({size} > {max_size})"))),
+                            ws_write_timeout,
                         ).await {
                             debug!("failed to send notice (reason: {}), closing connection (cid: {})", reason, cid);
                             metrics.disconnects.with_label_values(&[reason]).inc();
@@ -1580,7 +1585,7 @@ async fn nostr_server(
                                 if e.is_expired() {
                                     metrics.events_rejected.with_label_values(&["expired"]).inc();
                                     let notice = Notice::invalid(e.id, "The event has already expired");
-                                    if let Err(reason) = ws_send(&mut ws_stream, make_notice_message(&notice)).await {
+                                    if let Err(reason) = ws_send(&mut ws_stream, make_notice_message(&notice), ws_write_timeout).await {
                                         debug!("failed to send notice (reason: {}), closing connection (cid: {})", reason, cid);
                                         metrics.disconnects.with_label_values(&[reason]).inc();
                                         break;
@@ -1604,7 +1609,7 @@ async fn nostr_server(
                                     if let Some(fut_sec) = settings.options.reject_future_seconds {
                                         let msg = format!("The event created_at field is out of the acceptable range (+{fut_sec}sec) for this relay.");
                                         let notice = Notice::invalid(e.id, &msg);
-                                        if let Err(reason) = ws_send(&mut ws_stream, make_notice_message(&notice)).await {
+                                        if let Err(reason) = ws_send(&mut ws_stream, make_notice_message(&notice), ws_write_timeout).await {
                                             debug!("failed to send notice (reason: {}), closing connection (cid: {})", reason, cid);
                                             metrics.disconnects.with_label_values(&[reason]).inc();
                                             break;
@@ -1631,7 +1636,7 @@ async fn nostr_server(
                                                     };
                                                     info!("client is authenticated: (cid: {}, pubkey: {:?})", cid, pubkey);
                                                     // Send OK message to confirm successful authentication (NIP-42)
-                                                    if let Err(reason) = ws_send(&mut ws_stream, make_notice_message(&Notice::saved(event.id))).await {
+                                                    if let Err(reason) = ws_send(&mut ws_stream, make_notice_message(&Notice::saved(event.id)), ws_write_timeout).await {
                                                         debug!("failed to send notice (reason: {}), closing connection (cid: {})", reason, cid);
                                                         metrics.disconnects.with_label_values(&[reason]).inc();
                                                         break;
@@ -1639,7 +1644,7 @@ async fn nostr_server(
                                                 },
                                                 Err(e) => {
                                                     info!("authentication error: {} (cid: {})", e, cid);
-                                                    if let Err(reason) = ws_send(&mut ws_stream, make_notice_message(&Notice::restricted(event.id, format!("authentication error: {e}").as_str()))).await {
+                                                    if let Err(reason) = ws_send(&mut ws_stream, make_notice_message(&Notice::restricted(event.id, format!("authentication error: {e}").as_str())), ws_write_timeout).await {
                                                         debug!("failed to send notice (reason: {}), closing connection (cid: {})", reason, cid);
                                                         metrics.disconnects.with_label_values(&[reason]).inc();
                                                         break;
@@ -1651,7 +1656,7 @@ async fn nostr_server(
                                 } else {
                                     let e = CommandUnknownError;
                                     info!("client sent an invalid event (cid: {})", cid);
-                                    if let Err(reason) = ws_send(&mut ws_stream, make_notice_message(&Notice::invalid(evid, &format!("{e}")))).await {
+                                    if let Err(reason) = ws_send(&mut ws_stream, make_notice_message(&Notice::invalid(evid, &format!("{e}"))), ws_write_timeout).await {
                                         debug!("failed to send notice (reason: {}), closing connection (cid: {})", reason, cid);
                                         metrics.disconnects.with_label_values(&[reason]).inc();
                                         break;
@@ -1661,7 +1666,7 @@ async fn nostr_server(
                             Err(e) => {
                                 metrics.cmd_event.inc();
                                 info!("client sent an invalid event (cid: {})", cid);
-                                if let Err(reason) = ws_send(&mut ws_stream, make_notice_message(&Notice::invalid(evid, &format!("{e}")))).await {
+                                if let Err(reason) = ws_send(&mut ws_stream, make_notice_message(&Notice::invalid(evid, &format!("{e}"))), ws_write_timeout).await {
                                     debug!("failed to send notice (reason: {}), closing connection (cid: {})", reason, cid);
                                     metrics.disconnects.with_label_values(&[reason]).inc();
                                     break;
@@ -1686,7 +1691,7 @@ async fn nostr_server(
                             }
                             if settings.limits.limit_scrapers && s.is_scraper() {
                                 info!("subscription was scraper, ignoring (cid: {}, sub: {:?})", cid, s.id);
-                                if let Err(reason) = ws_send(&mut ws_stream, Message::Text(format!("[\"EOSE\",\"{}\"]", s.id))).await {
+                                if let Err(reason) = ws_send(&mut ws_stream, Message::Text(format!("[\"EOSE\",\"{}\"]", s.id)), ws_write_timeout).await {
                                     debug!("failed to send message (reason: {}), closing connection (cid: {})", reason, cid);
                                     metrics.disconnects.with_label_values(&[reason]).inc();
                                     break;
@@ -1718,7 +1723,7 @@ async fn nostr_server(
                                 },
                                 Err(e) => {
                                     info!("Subscription error: {} (cid: {}, sub: {:?})", e, cid, s.id);
-                                    if let Err(reason) = ws_send(&mut ws_stream, make_notice_message(&Notice::message(format!("Subscription error: {e}")))).await {
+                                    if let Err(reason) = ws_send(&mut ws_stream, make_notice_message(&Notice::message(format!("Subscription error: {e}"))), ws_write_timeout).await {
                                         debug!("failed to send notice (reason: {}), closing connection (cid: {})", reason, cid);
                                         metrics.disconnects.with_label_values(&[reason]).inc();
                                         break;
@@ -1748,7 +1753,7 @@ async fn nostr_server(
                             }
                         } else {
                             info!("invalid command ignored");
-                            if let Err(reason) = ws_send(&mut ws_stream, make_notice_message(&Notice::message("could not parse command".into()))).await {
+                            if let Err(reason) = ws_send(&mut ws_stream, make_notice_message(&Notice::message("could not parse command".into())), ws_write_timeout).await {
                                 debug!("failed to send notice (reason: {}), closing connection (cid: {})", reason, cid);
                                 metrics.disconnects.with_label_values(&[reason]).inc();
                                 break;
@@ -1761,7 +1766,7 @@ async fn nostr_server(
                     }
                     Err(Error::EventMaxLengthError(s)) => {
                         info!("client sent command larger ({} bytes) than max size (cid: {})", s, cid);
-                        if let Err(reason) = ws_send(&mut ws_stream, make_notice_message(&Notice::message("event exceeded max size".into()))).await {
+                        if let Err(reason) = ws_send(&mut ws_stream, make_notice_message(&Notice::message("event exceeded max size".into())), ws_write_timeout).await {
                             debug!("failed to send notice (reason: {}), closing connection (cid: {})", reason, cid);
                             metrics.disconnects.with_label_values(&[reason]).inc();
                             break;
@@ -1769,7 +1774,7 @@ async fn nostr_server(
                     },
                     Err(Error::ProtoParseError) => {
                         info!("client sent command that could not be parsed (cid: {})", cid);
-                        if let Err(reason) = ws_send(&mut ws_stream, make_notice_message(&Notice::message("could not parse command".into()))).await {
+                        if let Err(reason) = ws_send(&mut ws_stream, make_notice_message(&Notice::message("could not parse command".into())), ws_write_timeout).await {
                             debug!("failed to send notice (reason: {}), closing connection (cid: {})", reason, cid);
                             metrics.disconnects.with_label_values(&[reason]).inc();
                             break;

--- a/src/server.rs
+++ b/src/server.rs
@@ -1245,6 +1245,28 @@ fn make_notice_message(notice: &Notice) -> Message {
     Message::text(json.to_string())
 }
 
+/// Hard cap on how long a single WebSocket send can take. Without this, a
+/// dead-but-not-RST'd peer can keep `ws_stream.send().await` blocked for as
+/// long as TCP retransmits run — `tcp_retries2 * exponential backoff` ≈ 15
+/// minutes on Linux defaults — pinning the connection task and starving
+/// the ping/shutdown arms of the select loop the whole time.
+const WS_WRITE_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Send a message on the WebSocket sink with a write-side timeout. On
+/// failure, returns the disconnect-reason label for the metrics counter:
+/// `"send_error"` (sink errored) or `"write_timeout"` (peer didn't drain
+/// within `WS_WRITE_TIMEOUT`).
+async fn ws_send(
+    ws: &mut WebSocketStream<Upgraded>,
+    msg: Message,
+) -> Result<(), &'static str> {
+    match tokio::time::timeout(WS_WRITE_TIMEOUT, ws.send(msg)).await {
+        Ok(Ok(())) => Ok(()),
+        Ok(Err(_)) => Err("send_error"),
+        Err(_) => Err("write_timeout"),
+    }
+}
+
 fn allowed_to_send(event_str: &str, conn: &conn::ClientConn, settings: &Settings) -> bool {
     // TODO: pass in kind so that we can avoid deserialization for most events
     if settings.authorization.nip42_dms {
@@ -1355,12 +1377,11 @@ async fn nostr_server(
     if settings.authorization.nip42_auth {
         conn.generate_auth_challenge();
         if let Some(challenge) = conn.auth_challenge() {
-            ws_stream
-                .send(make_notice_message(&Notice::AuthChallenge(
-                    challenge.to_string(),
-                )))
-                .await
-                .ok();
+            let _ = ws_send(
+                &mut ws_stream,
+                make_notice_message(&Notice::AuthChallenge(challenge.to_string())),
+            )
+            .await;
         }
     }
 
@@ -1381,16 +1402,16 @@ async fn nostr_server(
                     break;
                 }
                 // Send a ping
-                if ws_stream.send(Message::Ping(Vec::new())).await.is_err() {
+                if let Err(reason) = ws_send(&mut ws_stream, Message::Ping(Vec::new())).await {
                     debug!("failed to send ping, closing connection (cid: {})", cid);
-                    metrics.disconnects.with_label_values(&["send_error"]).inc();
+                    metrics.disconnects.with_label_values(&[reason]).inc();
                     break;
                 }
             },
             Some(notice_msg) = notice_rx.recv() => {
-                if ws_stream.send(make_notice_message(&notice_msg)).await.is_err() {
-                    debug!("failed to send ping, closing connection (cid: {})", cid);
-                    metrics.disconnects.with_label_values(&["send_error"]).inc();
+                if let Err(reason) = ws_send(&mut ws_stream, make_notice_message(&notice_msg)).await {
+                    debug!("failed to send notice, closing connection (cid: {})", cid);
+                    metrics.disconnects.with_label_values(&[reason]).inc();
                     break;
                 }
             },
@@ -1399,9 +1420,9 @@ async fn nostr_server(
                 let subesc = query_result.sub_id.replace('"', "");
                 if query_result.event == "EOSE" {
                     let send_str = format!("[\"EOSE\",\"{subesc}\"]");
-                    if ws_stream.send(Message::Text(send_str)).await.is_err() {
+                    if let Err(reason) = ws_send(&mut ws_stream, Message::Text(send_str)).await {
                         debug!("failed to send message, closing connection (cid: {})", cid);
-                        metrics.disconnects.with_label_values(&["send_error"]).inc();
+                        metrics.disconnects.with_label_values(&[reason]).inc();
                         break;
                     }
                 } else if allowed_to_send(&query_result.event, &conn, &settings) {
@@ -1409,9 +1430,9 @@ async fn nostr_server(
                     client_received_event_count += 1;
                     // send a result
                     let send_str = format!("[\"EVENT\",\"{}\",{}]", subesc, &query_result.event);
-                    if ws_stream.send(Message::Text(send_str)).await.is_err() {
+                    if let Err(reason) = ws_send(&mut ws_stream, Message::Text(send_str)).await {
                         debug!("failed to send message, closing connection (cid: {})", cid);
-                        metrics.disconnects.with_label_values(&["send_error"]).inc();
+                        metrics.disconnects.with_label_values(&[reason]).inc();
                         break;
                     }
                 }
@@ -1454,9 +1475,9 @@ async fn nostr_server(
                                global_event.get_event_id_prefix());
                             let subesc = s.replace('"', "");
                             metrics.sent_events.with_label_values(&["realtime"]).inc();
-                            if ws_stream.send(Message::Text(format!("[\"EVENT\",\"{subesc}\",{event_str}]"))).await.is_err() {
+                            if let Err(reason) = ws_send(&mut ws_stream, Message::Text(format!("[\"EVENT\",\"{subesc}\",{event_str}]"))).await {
                                 debug!("failed to send message, closing connection (cid: {})", cid);
-                                metrics.disconnects.with_label_values(&["send_error"]).inc();
+                                metrics.disconnects.with_label_values(&[reason]).inc();
                                 should_disconnect = true;
                                 break;
                             }
@@ -1479,10 +1500,12 @@ async fn nostr_server(
                     },
                     Some(Ok(Message::Binary(_))) => {
 
-                        if ws_stream.send(
-                            make_notice_message(&Notice::message("binary messages are not accepted".into()))).await.is_err() {
+                        if let Err(reason) = ws_send(
+                            &mut ws_stream,
+                            make_notice_message(&Notice::message("binary messages are not accepted".into())),
+                        ).await {
                             debug!("failed to send notice, closing connection (cid: {})", cid);
-                            metrics.disconnects.with_label_values(&["send_error"]).inc();
+                            metrics.disconnects.with_label_values(&[reason]).inc();
                             break;
                         }
                         continue;
@@ -1493,10 +1516,12 @@ async fn nostr_server(
                         continue;
                     },
                     Some(Err(WsError::Capacity(MessageTooLong{size, max_size}))) => {
-                        if ws_stream.send(
-                            make_notice_message(&Notice::message(format!("message too large ({size} > {max_size})")))).await.is_err() {
+                        if let Err(reason) = ws_send(
+                            &mut ws_stream,
+                            make_notice_message(&Notice::message(format!("message too large ({size} > {max_size})"))),
+                        ).await {
                             debug!("failed to send notice, closing connection (cid: {})", cid);
-                            metrics.disconnects.with_label_values(&["send_error"]).inc();
+                            metrics.disconnects.with_label_values(&[reason]).inc();
                             break;
                         }
                         continue;
@@ -1544,9 +1569,9 @@ async fn nostr_server(
                                 if e.is_expired() {
                                     metrics.events_rejected.with_label_values(&["expired"]).inc();
                                     let notice = Notice::invalid(e.id, "The event has already expired");
-                                    if ws_stream.send(make_notice_message(&notice)).await.is_err() {
+                                    if let Err(reason) = ws_send(&mut ws_stream, make_notice_message(&notice)).await {
                                         debug!("failed to send notice, closing connection (cid: {})", cid);
-                                        metrics.disconnects.with_label_values(&["send_error"]).inc();
+                                        metrics.disconnects.with_label_values(&[reason]).inc();
                                         break;
                                     }
                                     // check if the event is too far in the future.
@@ -1568,9 +1593,9 @@ async fn nostr_server(
                                     if let Some(fut_sec) = settings.options.reject_future_seconds {
                                         let msg = format!("The event created_at field is out of the acceptable range (+{fut_sec}sec) for this relay.");
                                         let notice = Notice::invalid(e.id, &msg);
-                                        if ws_stream.send(make_notice_message(&notice)).await.is_err() {
+                                        if let Err(reason) = ws_send(&mut ws_stream, make_notice_message(&notice)).await {
                                             debug!("failed to send notice, closing connection (cid: {})", cid);
-                                            metrics.disconnects.with_label_values(&["send_error"]).inc();
+                                            metrics.disconnects.with_label_values(&[reason]).inc();
                                             break;
 
                                         }
@@ -1595,17 +1620,17 @@ async fn nostr_server(
                                                     };
                                                     info!("client is authenticated: (cid: {}, pubkey: {:?})", cid, pubkey);
                                                     // Send OK message to confirm successful authentication (NIP-42)
-                                                    if ws_stream.send(make_notice_message(&Notice::saved(event.id))).await.is_err() {
+                                                    if let Err(reason) = ws_send(&mut ws_stream, make_notice_message(&Notice::saved(event.id))).await {
                                                         debug!("failed to send notice, closing connection (cid: {})", cid);
-                                                        metrics.disconnects.with_label_values(&["send_error"]).inc();
+                                                        metrics.disconnects.with_label_values(&[reason]).inc();
                                                         break;
                                                     }
                                                 },
                                                 Err(e) => {
                                                     info!("authentication error: {} (cid: {})", e, cid);
-                                                    if ws_stream.send(make_notice_message(&Notice::restricted(event.id, format!("authentication error: {e}").as_str()))).await.is_err() {
+                                                    if let Err(reason) = ws_send(&mut ws_stream, make_notice_message(&Notice::restricted(event.id, format!("authentication error: {e}").as_str()))).await {
                                                         debug!("failed to send notice, closing connection (cid: {})", cid);
-                                                        metrics.disconnects.with_label_values(&["send_error"]).inc();
+                                                        metrics.disconnects.with_label_values(&[reason]).inc();
                                                         break;
                                                     }
                                                 },
@@ -1615,9 +1640,9 @@ async fn nostr_server(
                                 } else {
                                     let e = CommandUnknownError;
                                     info!("client sent an invalid event (cid: {})", cid);
-                                    if ws_stream.send(make_notice_message(&Notice::invalid(evid, &format!("{e}")))).await.is_err() {
+                                    if let Err(reason) = ws_send(&mut ws_stream, make_notice_message(&Notice::invalid(evid, &format!("{e}")))).await {
                                         debug!("failed to send notice, closing connection (cid: {})", cid);
-                                        metrics.disconnects.with_label_values(&["send_error"]).inc();
+                                        metrics.disconnects.with_label_values(&[reason]).inc();
                                         break;
                                     }
                                 }
@@ -1625,9 +1650,9 @@ async fn nostr_server(
                             Err(e) => {
                                 metrics.cmd_event.inc();
                                 info!("client sent an invalid event (cid: {})", cid);
-                                if ws_stream.send(make_notice_message(&Notice::invalid(evid, &format!("{e}")))).await.is_err() {
+                                if let Err(reason) = ws_send(&mut ws_stream, make_notice_message(&Notice::invalid(evid, &format!("{e}")))).await {
                                     debug!("failed to send notice, closing connection (cid: {})", cid);
-                                    metrics.disconnects.with_label_values(&["send_error"]).inc();
+                                    metrics.disconnects.with_label_values(&[reason]).inc();
                                     break;
                                 }
                             }
@@ -1650,9 +1675,9 @@ async fn nostr_server(
                             }
                             if settings.limits.limit_scrapers && s.is_scraper() {
                                 info!("subscription was scraper, ignoring (cid: {}, sub: {:?})", cid, s.id);
-                                if ws_stream.send(Message::Text(format!("[\"EOSE\",\"{}\"]", s.id))).await.is_err() {
+                                if let Err(reason) = ws_send(&mut ws_stream, Message::Text(format!("[\"EOSE\",\"{}\"]", s.id))).await {
                                     debug!("failed to send message, closing connection (cid: {})", cid);
-                                    metrics.disconnects.with_label_values(&["send_error"]).inc();
+                                    metrics.disconnects.with_label_values(&[reason]).inc();
                                     break;
                                 }
                                 continue
@@ -1682,9 +1707,9 @@ async fn nostr_server(
                                 },
                                 Err(e) => {
                                     info!("Subscription error: {} (cid: {}, sub: {:?})", e, cid, s.id);
-                                    if ws_stream.send(make_notice_message(&Notice::message(format!("Subscription error: {e}")))).await.is_err() {
+                                    if let Err(reason) = ws_send(&mut ws_stream, make_notice_message(&Notice::message(format!("Subscription error: {e}")))).await {
                                         debug!("failed to send notice, closing connection (cid: {})", cid);
-                                        metrics.disconnects.with_label_values(&["send_error"]).inc();
+                                        metrics.disconnects.with_label_values(&[reason]).inc();
                                         break;
 
                                     }
@@ -1712,9 +1737,9 @@ async fn nostr_server(
                             }
                         } else {
                             info!("invalid command ignored");
-                            if ws_stream.send(make_notice_message(&Notice::message("could not parse command".into()))).await.is_err() {
+                            if let Err(reason) = ws_send(&mut ws_stream, make_notice_message(&Notice::message("could not parse command".into()))).await {
                                 debug!("failed to send notice, closing connection (cid: {})", cid);
-                                metrics.disconnects.with_label_values(&["send_error"]).inc();
+                                metrics.disconnects.with_label_values(&[reason]).inc();
                                 break;
                             }
                         }
@@ -1725,17 +1750,17 @@ async fn nostr_server(
                     }
                     Err(Error::EventMaxLengthError(s)) => {
                         info!("client sent command larger ({} bytes) than max size (cid: {})", s, cid);
-                        if ws_stream.send(make_notice_message(&Notice::message("event exceeded max size".into()))).await.is_err() {
+                        if let Err(reason) = ws_send(&mut ws_stream, make_notice_message(&Notice::message("event exceeded max size".into()))).await {
                             debug!("failed to send notice, closing connection (cid: {})", cid);
-                            metrics.disconnects.with_label_values(&["send_error"]).inc();
+                            metrics.disconnects.with_label_values(&[reason]).inc();
                             break;
                         }
                     },
                     Err(Error::ProtoParseError) => {
                         info!("client sent command that could not be parsed (cid: {})", cid);
-                        if ws_stream.send(make_notice_message(&Notice::message("could not parse command".into()))).await.is_err() {
+                        if let Err(reason) = ws_send(&mut ws_stream, make_notice_message(&Notice::message("could not parse command".into()))).await {
                             debug!("failed to send notice, closing connection (cid: {})", cid);
-                            metrics.disconnects.with_label_values(&["send_error"]).inc();
+                            metrics.disconnects.with_label_values(&[reason]).inc();
                             break;
                         }
                     },


### PR DESCRIPTION
Closes #4.

## Summary

Bound every `ws_stream.send().await` with a per-send write timeout. Surface the timeout case as a new `write_timeout` label on `nostr_disconnects_total`. Make the cap configurable via a new `limits.ws_write_timeout_seconds` setting (default 30s).

## Why

`ws_stream.send().await` was unbounded. A dead-but-not-RST'd peer (client-side middlebox dropping the connection silently, mobile network suspending the tab, residential CGNAT idle reap, etc.) could keep the future blocked for the full TCP retransmit window — `tcp_retries2` defaults give roughly 15 minutes on Linux. While that future was awaiting inside the connection's `tokio::select!` arm body, no other arm ran:

- the `ping_interval.tick` arm couldn't fire — keep-alive starved
- the `ws_next` arm couldn't read CLOSE / pings — `last_message_time` froze
- the `shutdown.recv` arm couldn't tick — graceful shutdown stalled

A single stuck peer pinned the entire connection task. Under load, zombie connections accumulate while the runtime still believes everything is fine.

## What changes

- New `ws_send(&mut WebSocketStream<Upgraded>, Message, Duration) -> Result<(), &'static str>` helper. Returns the metrics label as the error so each call site stays one-line.
- New `limits.ws_write_timeout_seconds: u32` setting (default **30**). Validated `> 0` at config load, returning `ConfigError::Message` (same pattern as `ping_interval_seconds`). 30s is generous for the default 128 KB max message size; if `max_ws_message_bytes` is raised to 1 MiB+ in production (as @MastaP's setup does), bump this to 60–90s. Sizing guidance is in `config.toml` and on the issue thread.
- All 19 send call sites in `nostr_server` (including the AUTH-challenge prelude, ping, notice, query result, broadcast, ws_next error/notice paths) route through `ws_send` with the configured timeout.
- New `nostr_disconnects_total` reason: `write_timeout` (distinct from `send_error`). Documented in `docs/metrics.md`.
- AUTH-challenge prelude now handles send failure: log + increment disconnect + early `return`. Previously discarded the result, leaving the connection alive but doomed.
- `ws_send` logs the underlying `WsError` at debug level before returning the metric label, so the cause survives in trace logs even though only the label propagates.
- All 18 in-loop call-site debug logs now include the disconnect reason: `failed to send notice (reason: write_timeout), closing connection (cid: …)`.
- Drive-by: pre-existing typo at the bottom of the `ws_next` match — `info!("…cid: {}, error: {:?}"` had an unclosed `(` in the format string. Closed.

## Relationship to other PRs

- #9 (merged) — config-side fix that lowered ping interval and shrank the dead-zombie window from 20min to 5min.
- #10 (merged) — `db_writer` rate-limit sleep is now async + shutdown-aware.
- #11 (open) — adds `nostr_broadcast_lagged_total` so we can *see* slow consumers.
- This PR — bounds the worst case so slow consumers don't pin the task indefinitely.

The four together make slow-consumer pathologies both observable and survivable.

## Test plan

- [ ] `cargo check` clean
- [ ] `cargo clippy` no new warnings
- [ ] `cargo test --all` passes — includes a new `rejects_zero_ws_write_timeout` test alongside the existing config-validation tests
- [ ] Post-deploy: confirm `nostr_disconnects_total{reason="write_timeout"}` shows up at value 0 on `/metrics`. Real values would show up only when an actual stuck-write event occurs. If `write_timeout` ticks on healthy connections, raise `ws_write_timeout_seconds` and revisit.
- [ ] Sanity-check the 1 MiB prod setting: verify `ws_write_timeout_seconds` is set to 60+ in the prod config before deploy, since defaults aren't enough at that message size.

## Out of scope

Reader/writer task split (the proper architectural fix sketched in #4) — substantially bigger refactor, defer to a follow-up if observability + the timeout cap aren't enough.