### PR TITLE
fix: add m007 extended statistics for OR-disjunction event lookups (#17)

### DIFF
--- a/src/repo/postgres_migration.rs
+++ b/src/repo/postgres_migration.rs
@@ -477,11 +477,15 @@ mod m006 {
 ///
 /// Creating the statistics is cheap; the `ANALYZE` afterwards is what
 /// actually populates them. ANALYZE is non-blocking for reads and
-/// writes but samples the table and can take ~30 s on a multi-million
-/// row event table. The TCP listener doesn't bind until
-/// `run_migrations` returns, so a fresh container is unreachable
-/// during ANALYZE — same situation as m006's CONCURRENTLY index
-/// builds, typically absorbed by the ECS health-check grace period.
+/// writes but samples the table; the call below is column-scoped to
+/// `(kind, pub_key, delegated_by)` so only those columns and any
+/// extended-stats objects that cover only those columns get
+/// recomputed — both new objects qualify, and a wide table avoids
+/// re-sampling per-column stats it doesn't need. The TCP listener
+/// doesn't bind until `run_migrations` returns, so a fresh container
+/// is unreachable during ANALYZE — same situation as m006's
+/// CONCURRENTLY index builds, typically absorbed by the ECS
+/// health-check grace period.
 ///
 /// Re-uses the m006 pattern: single connection, session-level
 /// `pg_advisory_lock` to serialize concurrent startups, re-check
@@ -533,22 +537,37 @@ mod m007 {
             return Ok(());
         }
 
+        // Schema-qualify the stats object names. CREATE STATISTICS
+        // honors search_path for the new object's schema even when
+        // the source table is schema-qualified, so an unqualified
+        // name could land the stats in whatever schema is first in
+        // the connection's search_path — silently invisible to the
+        // planner against public."event". Same defensive convention
+        // as elsewhere in this crate (see m006).
         info!("m007: creating extended statistics on (kind, pub_key) and (kind, delegated_by)");
         (&mut *conn)
             .execute(
-                r#"CREATE STATISTICS IF NOT EXISTS event_kind_pub_key_stats
+                r#"CREATE STATISTICS IF NOT EXISTS public.event_kind_pub_key_stats
    (ndistinct, dependencies, mcv) ON kind, pub_key FROM public."event""#,
             )
             .await?;
         (&mut *conn)
             .execute(
-                r#"CREATE STATISTICS IF NOT EXISTS event_kind_delegated_by_stats
+                r#"CREATE STATISTICS IF NOT EXISTS public.event_kind_delegated_by_stats
    (ndistinct, dependencies, mcv) ON kind, delegated_by FROM public."event""#,
             )
             .await?;
 
-        info!("m007: running ANALYZE on event to populate the new statistics (may take ~30s on large tables)");
-        (&mut *conn).execute(r#"ANALYZE public."event""#).await?;
+        // Column-scoped ANALYZE: only the listed columns get
+        // re-sampled, and any extended statistics whose columns are
+        // all in the list are re-populated. Both new stats objects
+        // qualify, so they end up populated, but we skip work for
+        // every other column on a wide table — meaningfully shorter
+        // wall-clock than a bare `ANALYZE event` on a 10M-row table.
+        info!("m007: running ANALYZE on event(kind, pub_key, delegated_by) to populate the new statistics");
+        (&mut *conn)
+            .execute(r#"ANALYZE public."event" (kind, pub_key, delegated_by)"#)
+            .await?;
 
         sqlx::query("INSERT INTO migrations VALUES ($1)")
             .bind(VERSION)

--- a/src/repo/postgres_migration.rs
+++ b/src/repo/postgres_migration.rs
@@ -38,6 +38,7 @@ pub async fn run_migrations(db: &PostgresPool) -> crate::error::Result<usize> {
     run_migration(m004::migration(), db).await;
     run_migration(m005::migration(), db).await;
     m006::run(db).await?;
+    m007::run(db).await?;
     Ok(current_version(db).await as usize)
 }
 
@@ -456,6 +457,102 @@ mod m006 {
             .execute(&mut *conn)
             .await?;
 
+        Ok(())
+    }
+}
+
+/// Add multivariate extended statistics on `(kind, pub_key)` and
+/// `(kind, delegated_by)`.
+///
+/// Without these, the planner has no idea that for a specific
+/// `pub_key` the `(kind, pub_key)` combination is highly selective —
+/// it estimates the conjunction by multiplying single-column
+/// selectivities and concludes the cheapest plan is to walk the
+/// `(created_at, kind)` index backward and filter. In production this
+/// turned a `WHERE (pub_key=X OR delegated_by=X) AND kind=K ORDER BY
+/// created_at DESC LIMIT 5` query into a 12 s scan of ~40 k random
+/// heap pages and re-saturated the connection pool that m006's
+/// composite indexes were supposed to relieve. The composite indexes
+/// existed and were valid; the planner just wasn't choosing them.
+///
+/// Creating the statistics is cheap; the `ANALYZE` afterwards is what
+/// actually populates them. ANALYZE is non-blocking for reads and
+/// writes but samples the table and can take ~30 s on a multi-million
+/// row event table — startup is delayed by that long the first time.
+///
+/// Re-uses the m006 pattern: single connection, session-level
+/// `pg_advisory_lock` to serialize concurrent startups, re-check
+/// inside the lock, idempotent SQL (`IF NOT EXISTS`) so it's a no-op
+/// on databases where an operator already applied the fix manually.
+mod m007 {
+    use crate::repo::postgres::PostgresPool;
+    use sqlx::pool::PoolConnection;
+    use sqlx::{Executor, Postgres};
+    use tracing::{info, warn};
+
+    pub const VERSION: i64 = 7;
+
+    /// ASCII bytes for `nosrm007` reinterpreted as a 64-bit integer.
+    const ADVISORY_LOCK_KEY: i64 = 0x6e6f_7372_6d30_3037_i64;
+
+    pub async fn run(db: &PostgresPool) -> crate::error::Result<()> {
+        let mut conn = db.acquire().await?;
+
+        sqlx::query("SELECT pg_advisory_lock($1)")
+            .bind(ADVISORY_LOCK_KEY)
+            .execute(&mut conn)
+            .await?;
+
+        let result = run_locked(&mut conn).await;
+
+        if let Err(e) = sqlx::query("SELECT pg_advisory_unlock($1)")
+            .bind(ADVISORY_LOCK_KEY)
+            .execute(&mut conn)
+            .await
+        {
+            warn!(
+                "m007: failed to release advisory lock {:#x}: {e}; \
+                 lock will release when connection closes",
+                ADVISORY_LOCK_KEY
+            );
+        }
+
+        result
+    }
+
+    async fn run_locked(conn: &mut PoolConnection<Postgres>) -> crate::error::Result<()> {
+        let applied: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM migrations WHERE serial_number = $1")
+                .bind(VERSION)
+                .fetch_one(&mut *conn)
+                .await?;
+        if applied > 0 {
+            return Ok(());
+        }
+
+        info!("m007: creating extended statistics on (kind, pub_key) and (kind, delegated_by)");
+        (&mut *conn)
+            .execute(
+                r#"CREATE STATISTICS IF NOT EXISTS event_kind_pub_key_stats
+   (ndistinct, dependencies, mcv) ON kind, pub_key FROM public."event""#,
+            )
+            .await?;
+        (&mut *conn)
+            .execute(
+                r#"CREATE STATISTICS IF NOT EXISTS event_kind_delegated_by_stats
+   (ndistinct, dependencies, mcv) ON kind, delegated_by FROM public."event""#,
+            )
+            .await?;
+
+        info!("m007: running ANALYZE on event to populate the new statistics (may take ~30s on large tables)");
+        (&mut *conn).execute(r#"ANALYZE public."event""#).await?;
+
+        sqlx::query("INSERT INTO migrations VALUES ($1)")
+            .bind(VERSION)
+            .execute(&mut *conn)
+            .await?;
+
+        info!("m007: complete");
         Ok(())
     }
 }

--- a/src/repo/postgres_migration.rs
+++ b/src/repo/postgres_migration.rs
@@ -478,7 +478,10 @@ mod m006 {
 /// Creating the statistics is cheap; the `ANALYZE` afterwards is what
 /// actually populates them. ANALYZE is non-blocking for reads and
 /// writes but samples the table and can take ~30 s on a multi-million
-/// row event table — startup is delayed by that long the first time.
+/// row event table. The TCP listener doesn't bind until
+/// `run_migrations` returns, so a fresh container is unreachable
+/// during ANALYZE — same situation as m006's CONCURRENTLY index
+/// builds, typically absorbed by the ECS health-check grace period.
 ///
 /// Re-uses the m006 pattern: single connection, session-level
 /// `pg_advisory_lock` to serialize concurrent startups, re-check


### PR DESCRIPTION
## Summary

- Adds Postgres migration **m007** that creates extended statistics on `(kind, pub_key)` and `(kind, delegated_by)` and runs `ANALYZE event`.
- Mirrors m006's pattern: single connection, session-level `pg_advisory_lock` (`nosrm007`), re-check inside the lock, idempotent `CREATE STATISTICS IF NOT EXISTS`.
- SQLite is unaffected — no equivalent feature, and the bug is Postgres-planner-specific.

## Why

May 1 ~07:45 UTC, prod (`sha-691c938`) re-entered the same buffer-pool / pool-exhaustion state #13 was supposed to fix. m006's composite indexes existed and were valid, but the planner wasn't picking them — without multivariate stats it estimates `(kind=K AND pub_key=X)` as the product of single-column selectivities, decides the cheap plan is to walk `event_created_at_idx` backward and filter, and ends up scanning ~40 k random heap pages per OR-disjunction lookup. Kind-30078 writes had stalled for ~10 hours behind 200 s read transactions.

After applying the statistics manually in prod:
- Dominant query: **30 910 ms → 1.134 ms** (~27 000x), buffer reads 40 962 → 6
- `db.load.avg` for that SQL: **51.5 → 5.5** (9x)

Without a migration, the manual fix is lost on snapshot restore and absent in any new environment provisioned from scratch — the next staging or recovery hits the same outage as soon as load arrives.

Full RCA in #17.

## Notes for deploy

- Production already has the statistics objects (applied manually today). When this rolls out, m007 will see them via `IF NOT EXISTS`, no-op the creation, run `ANALYZE` (which is non-blocking but ~30 s on a multi-million-row event table), and stamp `serial_number = 7`. Intended.
- Fresh environments / RDS restores now get the statistics from migration history instead of relying on operator memory.

## Test plan

- [x] `cargo check` clean
- [x] `cargo clippy` clean on the changed file (only pre-existing warnings in `bulkloader.rs`)
- [ ] Verify on a staging Postgres: m007 stamps the row, both stats objects exist, `ANALYZE` populates them, and the EXPLAIN plan for the canonical OR-disjunction query switches to BitmapOr over the m006 composite indexes
- [ ] Verify idempotence: re-run startup → no errors, no duplicate stats, version stays at 7
- [ ] Verify advisory-lock serialization: parallel ECS task start → exactly one runs the migration body, others see `applied > 0` and exit cleanly

Out of scope (called out in #17 for separate follow-up):
- Enable `pg_stat_statements` on the RDS parameter group
- Per-table autovacuum tuning for `event` if autoanalyze keeps falling behind

Closes #17.