### PR TITLE
fix: NIP-33 DELETE plan cliff on hot pubkeys — drive from tag side

### DIFF
--- a/src/repo/postgres.rs
+++ b/src/repo/postgres.rs
@@ -152,9 +152,16 @@ impl NostrRepo for PostgresRepo {
             }
         }
         if let Some(d_tag) = e.distinct_param() {
+            // Drive from tag (highly selective on value/value_hex) and use
+            // INNER JOIN so the planner can pick a tag-index-driven plan
+            // instead of scanning event rows for the (kind, pub_key) pair.
+            // LEFT JOIN here is semantically equivalent because the WHERE
+            // clause filters on right-side columns, but it has been observed
+            // to lock the planner into an outer-driven nested loop on hot
+            // pubkeys (see GH issue #19).
             let repl_count: i64 = if is_lower_hex(&d_tag) && (d_tag.len() % 2 == 0) {
                 sqlx::query_scalar(
-                    "SELECT count(*) AS count FROM event e LEFT JOIN tag t ON e.id=t.event_id WHERE e.pub_key=$1 AND e.kind=$2 AND t.name='d' AND t.value_hex=$3 AND e.created_at >= $4 LIMIT 1;")
+                    "SELECT count(*) AS count FROM tag t JOIN event e ON e.id=t.event_id WHERE t.name='d' AND t.value_hex=$3 AND e.pub_key=$1 AND e.kind=$2 AND e.created_at >= $4 LIMIT 1;")
                     .bind(hex::decode(&e.pubkey).ok())
                     .bind(e.kind as i64)
                     .bind(hex::decode(d_tag).ok())
@@ -163,7 +170,7 @@ impl NostrRepo for PostgresRepo {
                     .await?
             } else {
                 sqlx::query_scalar(
-                    "SELECT count(*) AS count FROM event e LEFT JOIN tag t ON e.id=t.event_id WHERE e.pub_key=$1 AND e.kind=$2 AND t.name='d' AND t.value=$3 AND e.created_at >= $4 LIMIT 1;")
+                    "SELECT count(*) AS count FROM tag t JOIN event e ON e.id=t.event_id WHERE t.name='d' AND t.value=$3 AND e.pub_key=$1 AND e.kind=$2 AND e.created_at >= $4 LIMIT 1;")
                     .bind(hex::decode(&e.pubkey).ok())
                     .bind(e.kind as i64)
                     .bind(d_tag.as_bytes())
@@ -253,15 +260,22 @@ ON CONFLICT (id) DO NOTHING"#,
         // parameterized replaceable events
         // check for parameterized replaceable events that would be hidden; don't insert these either.
         if let Some(d_tag) = e.distinct_param() {
+            // Drive the inner subquery from tag (see comment above on the
+            // existence-check query). With LEFT JOIN, the planner has been
+            // observed to scan millions of event rows for a hot pubkey and
+            // probe tag per row even when the result set is empty, causing
+            // multi-second persists on kind=3xxxx events. INNER JOIN with
+            // tag-first FROM lets the planner use the tag(value_hex) /
+            // tag(value) index up front (GH issue #19).
             let update_count = if is_lower_hex(&d_tag) && (d_tag.len() % 2 == 0) {
-                sqlx::query("DELETE FROM event WHERE kind=$1 AND pub_key=$2 AND id IN (SELECT e.id FROM event e LEFT JOIN tag t ON e.id=t.event_id WHERE e.kind=$1 AND e.pub_key=$2 AND t.name='d' AND t.value_hex=$3 ORDER BY created_at DESC OFFSET 1);")
+                sqlx::query("DELETE FROM event WHERE kind=$1 AND pub_key=$2 AND id IN (SELECT e.id FROM tag t JOIN event e ON e.id=t.event_id WHERE t.name='d' AND t.value_hex=$3 AND e.kind=$1 AND e.pub_key=$2 ORDER BY e.created_at DESC OFFSET 1);")
                     .bind(e.kind as i64)
                     .bind(hex::decode(&e.pubkey).ok())
                     .bind(hex::decode(d_tag).ok())
                     .execute(&mut tx)
                     .await?.rows_affected()
             } else {
-                sqlx::query("DELETE FROM event WHERE kind=$1 AND pub_key=$2 AND id IN (SELECT e.id FROM event e LEFT JOIN tag t ON e.id=t.event_id WHERE e.kind=$1 AND e.pub_key=$2 AND t.name='d' AND t.value=$3 ORDER BY created_at DESC OFFSET 1);")
+                sqlx::query("DELETE FROM event WHERE kind=$1 AND pub_key=$2 AND id IN (SELECT e.id FROM tag t JOIN event e ON e.id=t.event_id WHERE t.name='d' AND t.value=$3 AND e.kind=$1 AND e.pub_key=$2 ORDER BY e.created_at DESC OFFSET 1);")
                     .bind(e.kind as i64)
                     .bind(hex::decode(&e.pubkey).ok())
                     .bind(d_tag.as_bytes())

--- a/src/repo/postgres.rs
+++ b/src/repo/postgres.rs
@@ -159,29 +159,35 @@ impl NostrRepo for PostgresRepo {
             // clause filters on right-side columns, but it has been observed
             // to lock the planner into an outer-driven nested loop on hot
             // pubkeys (see GH issue #19).
-            let repl_count: i64 = if is_lower_hex(&d_tag) && (d_tag.len() % 2 == 0) {
-                sqlx::query_scalar(
-                    "SELECT count(*) AS count FROM tag t JOIN event e ON e.id=t.event_id WHERE t.name='d' AND t.value_hex=$3 AND e.pub_key=$1 AND e.kind=$2 AND e.created_at >= $4 LIMIT 1;")
+            //
+            // Existence-only probe: `SELECT 1 ... LIMIT 1` + fetch_optional
+            // lets the planner short-circuit on the first match. The earlier
+            // `SELECT count(*) ... LIMIT 1` shape was wrong — LIMIT does not
+            // apply to an aggregate row, so it forced a full count of all
+            // matches even though we only care whether ≥1 row exists.
+            let repl_exists = if is_lower_hex(&d_tag) && (d_tag.len() % 2 == 0) {
+                sqlx::query(
+                    "SELECT 1 FROM tag t JOIN event e ON e.id=t.event_id WHERE t.name='d' AND t.value_hex=$3 AND e.pub_key=$1 AND e.kind=$2 AND e.created_at >= $4 LIMIT 1;")
                     .bind(hex::decode(&e.pubkey).ok())
                     .bind(e.kind as i64)
                     .bind(hex::decode(d_tag).ok())
                     .bind(Utc.timestamp_opt(e.created_at as i64, 0).unwrap())
-                    .fetch_one(&mut tx)
+                    .fetch_optional(&mut tx)
                     .await?
             } else {
-                sqlx::query_scalar(
-                    "SELECT count(*) AS count FROM tag t JOIN event e ON e.id=t.event_id WHERE t.name='d' AND t.value=$3 AND e.pub_key=$1 AND e.kind=$2 AND e.created_at >= $4 LIMIT 1;")
+                sqlx::query(
+                    "SELECT 1 FROM tag t JOIN event e ON e.id=t.event_id WHERE t.name='d' AND t.value=$3 AND e.pub_key=$1 AND e.kind=$2 AND e.created_at >= $4 LIMIT 1;")
                     .bind(hex::decode(&e.pubkey).ok())
                     .bind(e.kind as i64)
                     .bind(d_tag.as_bytes())
                     .bind(Utc.timestamp_opt(e.created_at as i64, 0).unwrap())
-                    .fetch_one(&mut tx)
+                    .fetch_optional(&mut tx)
                     .await?
             };
             // if any rows were returned, then some newer event with
-            // the same author/kind/tag value exist, and we can ignore
+            // the same author/kind/tag value exists, and we can ignore
             // this event.
-            if repl_count > 0 {
+            if repl_exists.is_some() {
                 return Ok(0);
             }
         }

--- a/src/repo/sqlite.rs
+++ b/src/repo/sqlite.rs
@@ -159,7 +159,7 @@ impl SqliteRepo {
                 "SELECT e.id FROM tag t JOIN event e ON e.id=t.event_id WHERE t.name='d' AND t.value=? AND e.author=? AND e.kind=? AND e.created_at >= ? LIMIT 1;",
                 params![d_tag, pubkey_blob, e.kind, e.created_at],|row| row.get::<usize, usize>(0));
             // if any rows were returned, then some newer event with
-            // the same author/kind/tag value exist, and we can ignore
+            // the same author/kind/tag value exists, and we can ignore
             // this event.
             if repl_count.ok().is_some() {
                 return Ok(0);

--- a/src/repo/sqlite.rs
+++ b/src/repo/sqlite.rs
@@ -1726,15 +1726,18 @@ mod tests {
         );
     }
 
-    /// Regression test for GH issue #19 (production: 11-26s persist tail
-    /// for kind=31113 events on hot pubkeys).
+    /// Semantic regression test for GH issue #19 (production: 11-26s
+    /// persist tail for kind=31113 events on hot pubkeys).
     ///
-    /// Verifies the parameterized-replaceable DELETE correctly removes
-    /// older events when the d-tag value is non-hex (e.g.
-    /// `token-transfer-{ts}-{nonce}`) — the exact data shape that hit the
-    /// planner cliff in production. Locks in the new tag-driven INNER
-    /// JOIN form against an accidental revert to the LEFT-JOIN-from-event
-    /// shape.
+    /// Runs the same tag-driven INNER JOIN DELETE shape that
+    /// `persist_event` ships, against the exact non-hex d-tag value seen
+    /// in production (`token-transfer-{ts}-{nonce}`), and verifies older
+    /// rows are removed while the newest survives.
+    ///
+    /// This test does not call `persist_event` directly, so it cannot
+    /// catch a revert that changes only the SQL string in source. It is
+    /// a check on the DELETE's *semantics* — that the tag-first INNER
+    /// JOIN form correctly matches non-hex `value`-column rows.
     #[test]
     fn test_param_replaceable_delete_non_hex_d_tag() {
         let mut conn = rusqlite::Connection::open_in_memory().unwrap();

--- a/src/repo/sqlite.rs
+++ b/src/repo/sqlite.rs
@@ -151,10 +151,13 @@ impl SqliteRepo {
             }
         }
         // check for parameterized replaceable events that would be hidden; don't insert these either.
+        // Drive from tag side (INNER JOIN) so SQLite uses the tag(name,...,value,...)
+        // covering index instead of scanning event rows for the (kind, author) pair —
+        // critical for hot pubkeys with millions of events (GH issue #19).
         if let Some(d_tag) = e.distinct_param() {
             let repl_count = tx.query_row(
-                "SELECT e.id FROM event e LEFT JOIN tag t ON e.id=t.event_id WHERE e.author=? AND e.kind=? AND t.name='d' AND t.value=? AND e.created_at >= ? LIMIT 1;",
-                params![pubkey_blob, e.kind, d_tag, e.created_at],|row| row.get::<usize, usize>(0));
+                "SELECT e.id FROM tag t JOIN event e ON e.id=t.event_id WHERE t.name='d' AND t.value=? AND e.author=? AND e.kind=? AND e.created_at >= ? LIMIT 1;",
+                params![d_tag, pubkey_blob, e.kind, e.created_at],|row| row.get::<usize, usize>(0));
             // if any rows were returned, then some newer event with
             // the same author/kind/tag value exist, and we can ignore
             // this event.
@@ -211,10 +214,14 @@ impl SqliteRepo {
             }
         }
         // if this event is parameterized replaceable, remove other events.
+        // Drive from tag side (INNER JOIN) so SQLite picks the tag(name,kind,value,...)
+        // covering index up front. With LEFT JOIN the planner has been observed to
+        // scan event rows for the (kind, author) pair and probe tag per row, which
+        // balloons to multi-second runtimes on hot pubkeys (GH issue #19).
         if let Some(d_tag) = e.distinct_param() {
             let update_count = tx.execute(
-                "DELETE FROM event WHERE kind=? AND author=? AND id IN (SELECT e.id FROM event e LEFT JOIN tag t ON e.id=t.event_id WHERE e.kind=? AND e.author=? AND t.name='d' AND t.value=? ORDER BY t.created_at DESC LIMIT -1 OFFSET 1);",
-                params![e.kind, pubkey_blob, e.kind, pubkey_blob, d_tag])?;
+                "DELETE FROM event WHERE kind=? AND author=? AND id IN (SELECT e.id FROM tag t JOIN event e ON e.id=t.event_id WHERE t.name='d' AND t.value=? AND e.kind=? AND e.author=? ORDER BY t.created_at DESC LIMIT -1 OFFSET 1);",
+                params![e.kind, pubkey_blob, d_tag, e.kind, pubkey_blob])?;
             if update_count > 0 {
                 info!(
                     "removed {} older parameterized replaceable kind {} events for author: {:?}",
@@ -1717,5 +1724,96 @@ mod tests {
             subquery_count, 2,
             "Should have 2 subqueries for 2 different tag keys"
         );
+    }
+
+    /// Regression test for GH issue #19 (production: 11-26s persist tail
+    /// for kind=31113 events on hot pubkeys).
+    ///
+    /// Verifies the parameterized-replaceable DELETE correctly removes
+    /// older events when the d-tag value is non-hex (e.g.
+    /// `token-transfer-{ts}-{nonce}`) — the exact data shape that hit the
+    /// planner cliff in production. Locks in the new tag-driven INNER
+    /// JOIN form against an accidental revert to the LEFT-JOIN-from-event
+    /// shape.
+    #[test]
+    fn test_param_replaceable_delete_non_hex_d_tag() {
+        let mut conn = rusqlite::Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            r#"
+            CREATE TABLE event (
+                id INTEGER PRIMARY KEY,
+                event_hash BLOB NOT NULL,
+                first_seen INTEGER NOT NULL,
+                created_at INTEGER NOT NULL,
+                expires_at INTEGER,
+                author BLOB NOT NULL,
+                delegated_by BLOB,
+                kind INTEGER NOT NULL,
+                hidden INTEGER,
+                content TEXT NOT NULL
+            );
+            CREATE TABLE tag (
+                id INTEGER PRIMARY KEY,
+                event_id INTEGER NOT NULL,
+                name TEXT,
+                value TEXT,
+                value_hex BLOB,
+                created_at INTEGER NOT NULL,
+                kind INTEGER NOT NULL,
+                FOREIGN KEY(event_id) REFERENCES event(id) ON DELETE CASCADE
+            );
+            "#,
+        )
+        .unwrap();
+
+        let author: Vec<u8> = vec![0xab; 32];
+        let kind: i64 = 30_000;
+        let d_tag = "token-transfer-1778147372148-kdgqnh";
+
+        // Insert three events with the same (author, kind, d-tag) at
+        // increasing created_at; mirrors the row state right after the
+        // newest of three replaceable events has been INSERTed.
+        let tx = conn.transaction().unwrap();
+        for (ev_pk, t) in [(1i64, 100i64), (2, 200), (3, 300)] {
+            tx.execute(
+                "INSERT INTO event (id, event_hash, first_seen, created_at, author, kind, content) \
+                 VALUES (?1, ?2, 0, ?3, ?4, ?5, '');",
+                params![ev_pk, vec![ev_pk as u8; 32], t, author, kind],
+            )
+            .unwrap();
+            tx.execute(
+                "INSERT INTO tag (event_id, name, value, kind, created_at) \
+                 VALUES (?1, 'd', ?2, ?3, ?4);",
+                params![ev_pk, d_tag, kind, t],
+            )
+            .unwrap();
+        }
+        tx.commit().unwrap();
+
+        // Run the parameterized-replaceable DELETE — same SQL string as
+        // SqliteRepo::persist_event uses. If a future edit reverts the
+        // `tag t JOIN event e` form back to `event e LEFT JOIN tag t`,
+        // we still want this test to keep passing semantically — but
+        // copying the literal SQL also catches accidental binding/
+        // ordering breakage.
+        let pubkey_blob = author.clone();
+        let deleted = conn
+            .execute(
+                "DELETE FROM event WHERE kind=? AND author=? AND id IN (SELECT e.id FROM tag t JOIN event e ON e.id=t.event_id WHERE t.name='d' AND t.value=? AND e.kind=? AND e.author=? ORDER BY t.created_at DESC LIMIT -1 OFFSET 1);",
+                params![kind, pubkey_blob, d_tag, kind, pubkey_blob],
+            )
+            .unwrap();
+
+        assert_eq!(deleted, 2, "expected the two older versions to be deleted");
+
+        // Newest event (id=3, created_at=300) must survive.
+        let remaining: Vec<i64> = conn
+            .prepare("SELECT id FROM event ORDER BY id;")
+            .unwrap()
+            .query_map([], |r| r.get(0))
+            .unwrap()
+            .map(|r| r.unwrap())
+            .collect();
+        assert_eq!(remaining, vec![3]);
     }
 }


### PR DESCRIPTION
Fixes #19.

## Summary

The parameterized-replaceable existence-check and DELETE used
`event e LEFT JOIN tag t ...`. On a deployed instance where one pubkey
holds 2.1M `kind=31113` events, the Postgres planner picked an
outer-driven nested loop over millions of `event` rows and probed `tag`
per row, even though the WHERE-side filter on `t.value(_hex)=$3` always
reduced the set to ~0 rows. ~0.5% of persists were taking **11–26 s**,
surfacing as Sphere wallet *"Send queue timeout"* and client *"appears
stale"* reconnects.

Production measurements (eu-west-1, 60 min):

| Bucket    | Count   |
|-----------|---------|
| <50 ms    | 26,430  |
| 50-200 ms | 2,063   |
| 200 ms-1s | 29      |
| **≥10 s** | **132** |

Every persist in the `≥10 s` bucket is `kind=31113` on the hot pubkey.

## Fix

Promote `LEFT JOIN` to `INNER JOIN` and put `tag` first in `FROM`, so the
planner can drive from `tag(value_hex)` / `tag(value)` (highly selective
on a unique d-tag like `token-transfer-{ts}-{nonce}`) and probe `event`
by primary key. `LEFT JOIN` with a non-NULL filter on right-side columns
is semantically equivalent to `INNER JOIN` — making it explicit unblocks
the planner's join-reorder choices.

Applied in both backends (Postgres + SQLite) so the two engines stay in
shape-parity. Touches four queries in `src/repo/postgres.rs` (existence
check + DELETE, both `value` and `value_hex` branches) and two in
`src/repo/sqlite.rs`.

## Why this is the right shape

- `tag(value_hex)` and `tag(value)` btree indexes already exist (m001/m002 in pg, base schema in sqlite).
- For NIP-33's intended dedup, prior versions of the same `(author, kind, d)` are at most a handful of rows — driving from `tag` keeps that small for any pubkey, no matter how skewed.
- The change is plan-only; no schema changes, no migration, no config flag.

## Test plan

- [x] `cargo check`
- [x] `cargo clippy --all-targets`
- [x] `cargo test --all` (3 consecutive clean runs, 104 tests)
- [x] New regression test `test_param_replaceable_delete_non_hex_d_tag` in `src/repo/sqlite.rs` — inserts 3 events with the exact production d-tag shape `token-transfer-1778147372148-kdgqnh` and asserts only the newest survives the DELETE
- [ ] Post-merge: confirm deployed `unicity-nostr-relay-eu` no longer shows `kind=31113` persists in the `≥10 s` bucket

## Notes / follow-ups

- Two of the issue's other suggested fixes (skip NIP-33 dedup entirely for kinds where it's a no-op, add slow-DELETE histograms) are deliberately out of scope here. This PR is the smallest semantic fix; if the planner cliff persists in production after deploy, a kind-allowlist bypass is the next step.
- The kind=5 deletion-tracking query at `postgres.rs:312` uses the same `event LEFT JOIN tag` shape with a WHERE-side filter (`t."name"='e' AND t.value=$2`). It hasn't been observed misbehaving yet, so it is left alone here, but it is the same anti-pattern and worth a follow-up audit.