### PR TITLE
feat: nip33_skip_dedup_kinds — bypass NIP-33 dedup per kind

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -63,6 +63,16 @@ description = "A newly created nostr-rs-relay.\n\nCustomize this with your own i
 # different nodes.  Ignore for single-database instances.
 #connection_write = "postgresql://postgres:nostr@localhost:7500/nostr"
 
+# Event kinds for which the relay should skip NIP-33 dedup work
+# (the pre-INSERT "is there a newer version?" check and the
+# post-INSERT "delete older versions" DELETE). Set this only for
+# kinds whose `d` tag is guaranteed unique by construction — the
+# dedup queries are no-ops in that case but still consume DB
+# resources on every persist. With this set, NIP-33 enforcement
+# becomes the publisher's / SDK's responsibility for these kinds.
+# Default: dedup runs for every parameterized-replaceable event (kinds 30000-39999).
+#nip33_skip_dedup_kinds = [31113]
+
 [logging]
 # Directory to store log files.  Log files roll over daily.
 #folder_path = "./log"

--- a/src/config.rs
+++ b/src/config.rs
@@ -27,6 +27,13 @@ pub struct Database {
     pub max_conn: u32,
     pub connection: String,
     pub connection_write: Option<String>,
+    /// Event kinds for which the relay should skip NIP-33
+    /// parameterized-replaceable dedup (the pre-INSERT existence check
+    /// and the post-INSERT DELETE of older versions). Intended for
+    /// applications that guarantee `d`-tag uniqueness by construction
+    /// — the dedup queries are no-ops in that case but still consume
+    /// DB resources on every persist. See issue #21.
+    pub nip33_skip_dedup_kinds: Option<Vec<u64>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -317,6 +324,7 @@ impl Default for Settings {
                 max_conn: 8,
                 connection: "".to_owned(),
                 connection_write: None,
+                nip33_skip_dedup_kinds: None,
             },
             grpc: Grpc {
                 event_admission_server: None,
@@ -493,5 +501,35 @@ ws_write_timeout_seconds = 0
             }
             other => panic!("expected ConfigError::Message for zero ws write timeout, got {other:?}"),
         }
+    }
+
+    /// Issue #21: `database.nip33_skip_dedup_kinds` must round-trip
+    /// through TOML loading and end up on the parsed `Settings`.
+    #[test]
+    fn nip33_skip_dedup_kinds_loads_from_toml() {
+        let path = write_temp_config(
+            r#"
+[database]
+nip33_skip_dedup_kinds = [31113, 31114]
+"#,
+        );
+        let result = Settings::new(&Some(path.to_string_lossy().to_string()));
+        std::fs::remove_file(&path).ok();
+        let settings = result.expect("valid skip-dedup list should load");
+        assert_eq!(
+            settings.database.nip33_skip_dedup_kinds,
+            Some(vec![31113, 31114])
+        );
+    }
+
+    /// Issue #21: when the key is absent, the field stays `None` so the
+    /// repos preserve canonical NIP-33 dedup behavior by default.
+    #[test]
+    fn nip33_skip_dedup_kinds_defaults_to_none() {
+        let path = write_temp_config("");
+        let result = Settings::new(&Some(path.to_string_lossy().to_string()));
+        std::fs::remove_file(&path).ok();
+        let settings = result.expect("empty config should load with defaults");
+        assert!(settings.database.nip33_skip_dedup_kinds.is_none());
     }
 }

--- a/src/db.rs
+++ b/src/db.rs
@@ -112,7 +112,20 @@ async fn build_postgres_pool(settings: &Settings, metrics: NostrMetrics) -> Post
     };
     metrics.db_pool_size.set(db_pool_size);
 
-    let repo = PostgresRepo::new(pool, write_pool, metrics, separate_write_pool);
+    let skip_dedup_kinds: std::collections::HashSet<u64> = settings
+        .database
+        .nip33_skip_dedup_kinds
+        .clone()
+        .unwrap_or_default()
+        .into_iter()
+        .collect();
+    let repo = PostgresRepo::new(
+        pool,
+        write_pool,
+        metrics,
+        separate_write_pool,
+        skip_dedup_kinds,
+    );
 
     // Panic on migration failure
     let version = repo.migrate_up().await.unwrap();

--- a/src/repo/postgres.rs
+++ b/src/repo/postgres.rs
@@ -160,49 +160,50 @@ impl NostrRepo for PostgresRepo {
                 return Ok(0);
             }
         }
-        if let Some(d_tag) = e.distinct_param().filter(|_| !self.skip_dedup_kinds.contains(&e.kind)) {
-            // Drive from tag (highly selective on value/value_hex) and use
-            // INNER JOIN so the planner can pick a tag-index-driven plan
-            // instead of scanning event rows for the (kind, pub_key) pair.
-            // LEFT JOIN here is semantically equivalent because the WHERE
-            // clause filters on right-side columns, but it has been observed
-            // to lock the planner into an outer-driven nested loop on hot
-            // pubkeys (see GH issue #19).
-            //
-            // Existence-only probe: `SELECT 1 ... LIMIT 1` + fetch_optional
-            // lets the planner short-circuit on the first match. The earlier
-            // `SELECT count(*) ... LIMIT 1` shape was wrong — LIMIT does not
-            // apply to an aggregate row, so it forced a full count of all
-            // matches even though we only care whether ≥1 row exists.
-            //
-            // Operators can opt a kind out of NIP-33 dedup entirely via
-            // `database.nip33_skip_dedup_kinds` — see issue #21. The
-            // `.filter()` above bypasses both this existence check and the
-            // post-INSERT DELETE block below for matching kinds.
-            let repl_exists = if is_lower_hex(&d_tag) && (d_tag.len() % 2 == 0) {
-                sqlx::query(
-                    "SELECT 1 FROM tag t JOIN event e ON e.id=t.event_id WHERE t.name='d' AND t.value_hex=$3 AND e.pub_key=$1 AND e.kind=$2 AND e.created_at >= $4 LIMIT 1;")
-                    .bind(hex::decode(&e.pubkey).ok())
-                    .bind(e.kind as i64)
-                    .bind(hex::decode(d_tag).ok())
-                    .bind(Utc.timestamp_opt(e.created_at as i64, 0).unwrap())
-                    .fetch_optional(&mut tx)
-                    .await?
-            } else {
-                sqlx::query(
-                    "SELECT 1 FROM tag t JOIN event e ON e.id=t.event_id WHERE t.name='d' AND t.value=$3 AND e.pub_key=$1 AND e.kind=$2 AND e.created_at >= $4 LIMIT 1;")
-                    .bind(hex::decode(&e.pubkey).ok())
-                    .bind(e.kind as i64)
-                    .bind(d_tag.as_bytes())
-                    .bind(Utc.timestamp_opt(e.created_at as i64, 0).unwrap())
-                    .fetch_optional(&mut tx)
-                    .await?
-            };
-            // if any rows were returned, then some newer event with
-            // the same author/kind/tag value exists, and we can ignore
-            // this event.
-            if repl_exists.is_some() {
-                return Ok(0);
+        // Operators can opt a kind out of NIP-33 dedup entirely via
+        // `database.nip33_skip_dedup_kinds` — see issue #21. Check the
+        // skip set *before* `distinct_param()` so a configured kind
+        // also skips the tag scan, matching the SQLite path.
+        if !self.skip_dedup_kinds.contains(&e.kind) {
+            if let Some(d_tag) = e.distinct_param() {
+                // Drive from tag (highly selective on value/value_hex) and use
+                // INNER JOIN so the planner can pick a tag-index-driven plan
+                // instead of scanning event rows for the (kind, pub_key) pair.
+                // LEFT JOIN here is semantically equivalent because the WHERE
+                // clause filters on right-side columns, but it has been observed
+                // to lock the planner into an outer-driven nested loop on hot
+                // pubkeys (see GH issue #19).
+                //
+                // Existence-only probe: `SELECT 1 ... LIMIT 1` + fetch_optional
+                // lets the planner short-circuit on the first match. The earlier
+                // `SELECT count(*) ... LIMIT 1` shape was wrong — LIMIT does not
+                // apply to an aggregate row, so it forced a full count of all
+                // matches even though we only care whether ≥1 row exists.
+                let repl_exists = if is_lower_hex(&d_tag) && (d_tag.len() % 2 == 0) {
+                    sqlx::query(
+                        "SELECT 1 FROM tag t JOIN event e ON e.id=t.event_id WHERE t.name='d' AND t.value_hex=$3 AND e.pub_key=$1 AND e.kind=$2 AND e.created_at >= $4 LIMIT 1;")
+                        .bind(hex::decode(&e.pubkey).ok())
+                        .bind(e.kind as i64)
+                        .bind(hex::decode(d_tag).ok())
+                        .bind(Utc.timestamp_opt(e.created_at as i64, 0).unwrap())
+                        .fetch_optional(&mut tx)
+                        .await?
+                } else {
+                    sqlx::query(
+                        "SELECT 1 FROM tag t JOIN event e ON e.id=t.event_id WHERE t.name='d' AND t.value=$3 AND e.pub_key=$1 AND e.kind=$2 AND e.created_at >= $4 LIMIT 1;")
+                        .bind(hex::decode(&e.pubkey).ok())
+                        .bind(e.kind as i64)
+                        .bind(d_tag.as_bytes())
+                        .bind(Utc.timestamp_opt(e.created_at as i64, 0).unwrap())
+                        .fetch_optional(&mut tx)
+                        .await?
+                };
+                // if any rows were returned, then some newer event with
+                // the same author/kind/tag value exists, and we can ignore
+                // this event.
+                if repl_exists.is_some() {
+                    return Ok(0);
+                }
             }
         }
         // ignore if the event hash is a duplicate.
@@ -279,37 +280,41 @@ ON CONFLICT (id) DO NOTHING"#,
         }
         // parameterized replaceable events
         // check for parameterized replaceable events that would be hidden; don't insert these either.
-        // Skipped entirely for kinds in `nip33_skip_dedup_kinds` (issue #21).
-        if let Some(d_tag) = e.distinct_param().filter(|_| !self.skip_dedup_kinds.contains(&e.kind)) {
-            // Drive the inner subquery from tag (see comment above on the
-            // existence-check query). With LEFT JOIN, the planner has been
-            // observed to scan millions of event rows for a hot pubkey and
-            // probe tag per row even when the result set is empty, causing
-            // multi-second persists on kind=3xxxx events. INNER JOIN with
-            // tag-first FROM lets the planner use the tag(value_hex) /
-            // tag(value) index up front (GH issue #19).
-            let update_count = if is_lower_hex(&d_tag) && (d_tag.len() % 2 == 0) {
-                sqlx::query("DELETE FROM event WHERE kind=$1 AND pub_key=$2 AND id IN (SELECT e.id FROM tag t JOIN event e ON e.id=t.event_id WHERE t.name='d' AND t.value_hex=$3 AND e.kind=$1 AND e.pub_key=$2 ORDER BY e.created_at DESC OFFSET 1);")
-                    .bind(e.kind as i64)
-                    .bind(hex::decode(&e.pubkey).ok())
-                    .bind(hex::decode(d_tag).ok())
-                    .execute(&mut tx)
-                    .await?.rows_affected()
-            } else {
-                sqlx::query("DELETE FROM event WHERE kind=$1 AND pub_key=$2 AND id IN (SELECT e.id FROM tag t JOIN event e ON e.id=t.event_id WHERE t.name='d' AND t.value=$3 AND e.kind=$1 AND e.pub_key=$2 ORDER BY e.created_at DESC OFFSET 1);")
-                    .bind(e.kind as i64)
-                    .bind(hex::decode(&e.pubkey).ok())
-                    .bind(d_tag.as_bytes())
-                    .execute(&mut tx)
-                    .await?.rows_affected()
-            };
-            if update_count > 0 {
-                info!(
-                    "removed {} older parameterized replaceable kind {} events for author: {:?}",
-                    update_count,
-                    e.kind,
-                    e.get_author_prefix()
-                );
+        // Skipped entirely for kinds in `nip33_skip_dedup_kinds` (issue
+        // #21). Skip-set check first so configured kinds also avoid
+        // the `distinct_param()` tag scan.
+        if !self.skip_dedup_kinds.contains(&e.kind) {
+            if let Some(d_tag) = e.distinct_param() {
+                // Drive the inner subquery from tag (see comment above on the
+                // existence-check query). With LEFT JOIN, the planner has been
+                // observed to scan millions of event rows for a hot pubkey and
+                // probe tag per row even when the result set is empty, causing
+                // multi-second persists on kind=3xxxx events. INNER JOIN with
+                // tag-first FROM lets the planner use the tag(value_hex) /
+                // tag(value) index up front (GH issue #19).
+                let update_count = if is_lower_hex(&d_tag) && (d_tag.len() % 2 == 0) {
+                    sqlx::query("DELETE FROM event WHERE kind=$1 AND pub_key=$2 AND id IN (SELECT e.id FROM tag t JOIN event e ON e.id=t.event_id WHERE t.name='d' AND t.value_hex=$3 AND e.kind=$1 AND e.pub_key=$2 ORDER BY e.created_at DESC OFFSET 1);")
+                        .bind(e.kind as i64)
+                        .bind(hex::decode(&e.pubkey).ok())
+                        .bind(hex::decode(d_tag).ok())
+                        .execute(&mut tx)
+                        .await?.rows_affected()
+                } else {
+                    sqlx::query("DELETE FROM event WHERE kind=$1 AND pub_key=$2 AND id IN (SELECT e.id FROM tag t JOIN event e ON e.id=t.event_id WHERE t.name='d' AND t.value=$3 AND e.kind=$1 AND e.pub_key=$2 ORDER BY e.created_at DESC OFFSET 1);")
+                        .bind(e.kind as i64)
+                        .bind(hex::decode(&e.pubkey).ok())
+                        .bind(d_tag.as_bytes())
+                        .execute(&mut tx)
+                        .await?.rows_affected()
+                };
+                if update_count > 0 {
+                    info!(
+                        "removed {} older parameterized replaceable kind {} events for author: {:?}",
+                        update_count,
+                        e.kind,
+                        e.get_author_prefix()
+                    );
+                }
             }
         }
         // if this event is a deletion, hide the referenced events from the same author.

--- a/src/repo/postgres.rs
+++ b/src/repo/postgres.rs
@@ -17,7 +17,9 @@ use nostr::key::Keys;
 use sqlx::postgres::PgRow;
 use sqlx::Error::RowNotFound;
 use sqlx::{Error, Execute, FromRow, Postgres, QueryBuilder, Row};
+use std::collections::HashSet;
 use std::ops::Deref;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 use tokio::sync::mpsc::Sender;
 use tokio::sync::oneshot::Receiver;
@@ -35,6 +37,11 @@ pub struct PostgresRepo {
     /// — pool metrics must read from one of them only, otherwise the
     /// in-use count would double-count the shared pool.
     separate_write_pool: bool,
+    /// Event kinds for which the relay skips NIP-33 dedup (existence
+    /// check + DELETE). Populated from
+    /// `database.nip33_skip_dedup_kinds` at construction. Empty set
+    /// (default) preserves canonical NIP-33 behavior. See issue #21.
+    skip_dedup_kinds: Arc<HashSet<u64>>,
 }
 
 impl PostgresRepo {
@@ -43,12 +50,14 @@ impl PostgresRepo {
         cw: PostgresPool,
         m: NostrMetrics,
         separate_write_pool: bool,
+        skip_dedup_kinds: HashSet<u64>,
     ) -> PostgresRepo {
         PostgresRepo {
             conn: c,
             conn_write: cw,
             metrics: m,
             separate_write_pool,
+            skip_dedup_kinds: Arc::new(skip_dedup_kinds),
         }
     }
 
@@ -151,7 +160,7 @@ impl NostrRepo for PostgresRepo {
                 return Ok(0);
             }
         }
-        if let Some(d_tag) = e.distinct_param() {
+        if let Some(d_tag) = e.distinct_param().filter(|_| !self.skip_dedup_kinds.contains(&e.kind)) {
             // Drive from tag (highly selective on value/value_hex) and use
             // INNER JOIN so the planner can pick a tag-index-driven plan
             // instead of scanning event rows for the (kind, pub_key) pair.
@@ -165,6 +174,11 @@ impl NostrRepo for PostgresRepo {
             // `SELECT count(*) ... LIMIT 1` shape was wrong — LIMIT does not
             // apply to an aggregate row, so it forced a full count of all
             // matches even though we only care whether ≥1 row exists.
+            //
+            // Operators can opt a kind out of NIP-33 dedup entirely via
+            // `database.nip33_skip_dedup_kinds` — see issue #21. The
+            // `.filter()` above bypasses both this existence check and the
+            // post-INSERT DELETE block below for matching kinds.
             let repl_exists = if is_lower_hex(&d_tag) && (d_tag.len() % 2 == 0) {
                 sqlx::query(
                     "SELECT 1 FROM tag t JOIN event e ON e.id=t.event_id WHERE t.name='d' AND t.value_hex=$3 AND e.pub_key=$1 AND e.kind=$2 AND e.created_at >= $4 LIMIT 1;")
@@ -265,7 +279,8 @@ ON CONFLICT (id) DO NOTHING"#,
         }
         // parameterized replaceable events
         // check for parameterized replaceable events that would be hidden; don't insert these either.
-        if let Some(d_tag) = e.distinct_param() {
+        // Skipped entirely for kinds in `nip33_skip_dedup_kinds` (issue #21).
+        if let Some(d_tag) = e.distinct_param().filter(|_| !self.skip_dedup_kinds.contains(&e.kind)) {
             // Drive the inner subquery from tag (see comment above on the
             // existence-check query). With LEFT JOIN, the planner has been
             // observed to scan millions of event rows for a hot pubkey and

--- a/src/repo/sqlite.rs
+++ b/src/repo/sqlite.rs
@@ -30,6 +30,7 @@ use tracing::{debug, info, trace, warn};
 
 use crate::repo::{now_jitter, NostrRepo};
 use nostr::key::Keys;
+use std::collections::HashSet;
 
 pub type SqlitePool = r2d2::Pool<r2d2_sqlite::SqliteConnectionManager>;
 pub type PooledConnection = r2d2::PooledConnection<r2d2_sqlite::SqliteConnectionManager>;
@@ -51,6 +52,11 @@ pub struct SqliteRepo {
     write_in_progress: Arc<Mutex<u64>>,
     /// Semaphore for readers to acquire blocking threads
     reader_threads_ready: Arc<Semaphore>,
+    /// Event kinds for which the relay skips NIP-33 dedup (existence
+    /// check + DELETE). Populated from
+    /// `database.nip33_skip_dedup_kinds` at construction. Empty set
+    /// (default) preserves canonical NIP-33 behavior. See issue #21.
+    skip_dedup_kinds: Arc<HashSet<u64>>,
 }
 
 impl SqliteRepo {
@@ -91,6 +97,15 @@ impl SqliteRepo {
         // to match the number of database reader connections.
         let max_conn = settings.database.max_conn as usize;
         let reader_threads_ready = Arc::new(Semaphore::new(max_conn));
+        let skip_dedup_kinds = Arc::new(
+            settings
+                .database
+                .nip33_skip_dedup_kinds
+                .clone()
+                .unwrap_or_default()
+                .into_iter()
+                .collect::<HashSet<u64>>(),
+        );
         SqliteRepo {
             metrics,
             read_pool,
@@ -99,6 +114,7 @@ impl SqliteRepo {
             checkpoint_in_progress,
             write_in_progress,
             reader_threads_ready,
+            skip_dedup_kinds,
         }
     }
 
@@ -129,7 +145,15 @@ impl SqliteRepo {
     }
 
     /// Persist an event to the database, returning rows added.
-    pub fn persist_event(conn: &mut PooledConnection, e: &Event) -> Result<u64> {
+    ///
+    /// `skip_dedup_kinds` is the set of event kinds for which to bypass
+    /// NIP-33 parameterized-replaceable dedup (see issue #21). Pass an
+    /// empty set to preserve canonical behavior.
+    pub fn persist_event(
+        conn: &mut PooledConnection,
+        e: &Event,
+        skip_dedup_kinds: &HashSet<u64>,
+    ) -> Result<u64> {
         // enable auto vacuum
         conn.execute_batch("pragma auto_vacuum = FULL")?;
 
@@ -154,15 +178,22 @@ impl SqliteRepo {
         // Drive from tag side (INNER JOIN) so SQLite uses the tag(name,...,value,...)
         // covering index instead of scanning event rows for the (kind, author) pair —
         // critical for hot pubkeys with millions of events (GH issue #19).
-        if let Some(d_tag) = e.distinct_param() {
-            let repl_count = tx.query_row(
-                "SELECT e.id FROM tag t JOIN event e ON e.id=t.event_id WHERE t.name='d' AND t.value=? AND e.author=? AND e.kind=? AND e.created_at >= ? LIMIT 1;",
-                params![d_tag, pubkey_blob, e.kind, e.created_at],|row| row.get::<usize, usize>(0));
-            // if any rows were returned, then some newer event with
-            // the same author/kind/tag value exists, and we can ignore
-            // this event.
-            if repl_count.ok().is_some() {
-                return Ok(0);
+        //
+        // Operators can opt a kind out of NIP-33 dedup entirely via
+        // `database.nip33_skip_dedup_kinds` for kinds whose `d` is
+        // unique by construction; the queries below are no-ops in that
+        // case but still consume DB resources (issue #21).
+        if !skip_dedup_kinds.contains(&e.kind) {
+            if let Some(d_tag) = e.distinct_param() {
+                let repl_count = tx.query_row(
+                    "SELECT e.id FROM tag t JOIN event e ON e.id=t.event_id WHERE t.name='d' AND t.value=? AND e.author=? AND e.kind=? AND e.created_at >= ? LIMIT 1;",
+                    params![d_tag, pubkey_blob, e.kind, e.created_at],|row| row.get::<usize, usize>(0));
+                // if any rows were returned, then some newer event with
+                // the same author/kind/tag value exists, and we can ignore
+                // this event.
+                if repl_count.ok().is_some() {
+                    return Ok(0);
+                }
             }
         }
         // ignore if the event hash is a duplicate.
@@ -218,17 +249,22 @@ impl SqliteRepo {
         // covering index up front. With LEFT JOIN the planner has been observed to
         // scan event rows for the (kind, author) pair and probe tag per row, which
         // balloons to multi-second runtimes on hot pubkeys (GH issue #19).
-        if let Some(d_tag) = e.distinct_param() {
-            let update_count = tx.execute(
-                "DELETE FROM event WHERE kind=? AND author=? AND id IN (SELECT e.id FROM tag t JOIN event e ON e.id=t.event_id WHERE t.name='d' AND t.value=? AND e.kind=? AND e.author=? ORDER BY t.created_at DESC LIMIT -1 OFFSET 1);",
-                params![e.kind, pubkey_blob, d_tag, e.kind, pubkey_blob])?;
-            if update_count > 0 {
-                info!(
-                    "removed {} older parameterized replaceable kind {} events for author: {:?}",
-                    update_count,
-                    e.kind,
-                    e.get_author_prefix()
-                );
+        //
+        // Skipped entirely for kinds in `nip33_skip_dedup_kinds`
+        // (issue #21).
+        if !skip_dedup_kinds.contains(&e.kind) {
+            if let Some(d_tag) = e.distinct_param() {
+                let update_count = tx.execute(
+                    "DELETE FROM event WHERE kind=? AND author=? AND id IN (SELECT e.id FROM tag t JOIN event e ON e.id=t.event_id WHERE t.name='d' AND t.value=? AND e.kind=? AND e.author=? ORDER BY t.created_at DESC LIMIT -1 OFFSET 1);",
+                    params![e.kind, pubkey_blob, d_tag, e.kind, pubkey_blob])?;
+                if update_count > 0 {
+                    info!(
+                        "removed {} older parameterized replaceable kind {} events for author: {:?}",
+                        update_count,
+                        e.kind,
+                        e.get_author_prefix()
+                    );
+                }
             }
         }
         // if this event is a deletion, hide the referenced events from the same author.
@@ -313,13 +349,14 @@ impl NostrRepo for SqliteRepo {
         //let mut conn = self.write_pool.get()?;
         let pool = self.write_pool.clone();
         let e = e.clone();
+        let skip = self.skip_dedup_kinds.clone();
         let event_count = task::spawn_blocking(move || {
             let mut conn = pool.get()?;
             // this could fail because the database was busy; try
             // multiple times before giving up.
             loop {
                 attempts += 1;
-                let wr = SqliteRepo::persist_event(&mut conn, &e);
+                let wr = SqliteRepo::persist_event(&mut conn, &e, &skip);
                 match wr {
                     Err(SqlError(rusqlite::Error::SqliteFailure(e, _))) => {
                         // this basically means that NIP-05 or another
@@ -1818,5 +1855,78 @@ mod tests {
             .map(|r| r.unwrap())
             .collect();
         assert_eq!(remaining, vec![3]);
+    }
+
+    /// Issue #21 — config-driven NIP-33 dedup bypass.
+    ///
+    /// Drives `SqliteRepo::persist_event` directly through 3 sequential
+    /// writes of the same `(author, kind=31113, d="token-transfer-...")`
+    /// triple, with `kind=31113` placed in the skip set. With dedup
+    /// bypassed, all 3 events must persist (no DELETE removes prior
+    /// versions). Without the bypass, only the newest would survive —
+    /// the existing `test_param_replaceable_delete_non_hex_d_tag`
+    /// covers that path.
+    #[test]
+    fn test_param_replaceable_dedup_bypass_for_skipped_kind() {
+        use crate::config::Settings;
+
+        let mut settings = Settings::default();
+        settings.database.in_memory = true;
+        settings.database.min_conn = 1;
+        settings.database.max_conn = 2;
+        settings.database.nip33_skip_dedup_kinds = Some(vec![31113]);
+
+        // Reuse the same metrics constructor the server uses, against
+        // a fresh prometheus registry, so we don't reimplement the
+        // (large) NostrMetrics shape here.
+        let (_registry, metrics) = crate::server::create_metrics();
+
+        let repo = SqliteRepo::new(&settings, metrics);
+        // Use a write-pool connection directly so we can run
+        // `persist_event` synchronously, mirroring the production write
+        // path without spinning up the async runtime.
+        let mut conn = repo.write_pool.get().unwrap();
+        upgrade_db(&mut conn).expect("schema upgrade");
+
+        let pubkey_hex = "ab".repeat(32);
+        let d_value = "token-transfer-1778147372148-kdgqnh";
+
+        // Three back-to-back persists of the same (author, kind, d)
+        // with monotonically increasing created_at. Each event needs
+        // a unique id so the `event_hash` UNIQUE constraint doesn't
+        // collapse them into one row before dedup even runs.
+        for (i, ts) in [(1u8, 100u64), (2, 200), (3, 300)] {
+            let mut id_bytes = [0u8; 32];
+            id_bytes[0] = i;
+            let event = Event {
+                id: hex::encode(id_bytes),
+                pubkey: pubkey_hex.clone(),
+                created_at: ts,
+                kind: 31113,
+                tags: vec![vec!["d".to_string(), d_value.to_string()]],
+                content: format!("event-{i}"),
+                sig: "00".repeat(64),
+                delegated_by: None,
+                tagidx: None,
+            };
+            let count = SqliteRepo::persist_event(&mut conn, &event, &repo.skip_dedup_kinds)
+                .expect("persist");
+            assert_eq!(count, 1, "each persist should insert one row");
+        }
+
+        // All three should still be present — the bypass kept the
+        // existence check from rejecting later events and the DELETE
+        // from removing earlier ones.
+        let remaining: i64 = conn
+            .query_row(
+                "SELECT count(*) FROM event WHERE kind=31113;",
+                [],
+                |r| r.get(0),
+            )
+            .unwrap();
+        assert_eq!(
+            remaining, 3,
+            "bypass must keep all 3 versions; got {remaining}"
+        );
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -694,7 +694,7 @@ async fn ctrl_c_or_signal(mut shutdown_signal: Receiver<()>) {
     }
 }
 
-fn create_metrics() -> (Registry, NostrMetrics) {
+pub(crate) fn create_metrics() -> (Registry, NostrMetrics) {
     // setup prometheus registry
     let registry = Registry::new();
 


### PR DESCRIPTION
Fixes #21.

## Summary

Add `[database] nip33_skip_dedup_kinds = [...]` to opt selected event kinds out of NIP-33 parameterized-replaceable enforcement entirely. With a kind in the list, the relay skips both:

- the pre-INSERT existence check (`SELECT 1 FROM tag t JOIN event e … WHERE t.value(_hex)=$3 … AND e.created_at >= $4`)
- the post-INSERT dedup DELETE (`DELETE FROM event … WHERE id IN (SELECT … ORDER BY created_at DESC OFFSET 1)`)

Persistence becomes a single `INSERT INTO event` plus tag fan-out — no NIP-33 enforcement queries. Default is `None` → behavior identical to today.

## Why

For applications that guarantee `d`-tag uniqueness by construction (e.g. unicity-tokens `kind=31113` with `d="token-transfer-{ts}-{nonce}"`), the dedup queries are always no-ops. They still consume DB resources on every persist:

- One round-trip to the existence-check SELECT
- One round-trip to the DELETE
- Both compete for the same buffer-pool partition latches and connection-pool slots as everything else

After PR #20 (JOIN-shape fix) the queries are fast in custom-plan mode, and after RDS-level `plan_cache_mode = force_custom_plan` the production tail latency dropped from 16 s → 0.19 s. This PR is **defense-in-depth on top of those**:

- Removes ~1 ms × inflow rate of wasted DB time
- Doesn't depend on the RDS parameter group setting
- Provides a path off the `force_custom_plan` band-aid if/when re-evaluated

## Tradeoffs

NIP-33 enforcement becomes the publisher's / SDK's responsibility for listed kinds. For kinds with truly unique `d`-tags, this changes no client-observable behavior — the queries would have matched 0 rows anyway. For misconfigured kinds (operator lists a kind whose `d`-tag is *not* unique), older versions accumulate until retention sweeps them, and "newer event already exists" rejection no longer fires.

## Implementation

- `src/config.rs`: `nip33_skip_dedup_kinds: Option<Vec<u64>>` on `Database`.
- `config.toml`: documented with worked example.
- `src/repo/sqlite.rs` / `src/repo/postgres.rs`: skip set cached as `Arc<HashSet<u64>>` on the repo struct, populated at construction. SQLite's `persist_event` now takes `&HashSet<u64>` (signature change); Postgres `write_event` accesses `self.skip_dedup_kinds` directly.
- `src/server.rs`: `create_metrics` is now `pub(crate)` so the SQLite test can build a `NostrMetrics` without reimplementing its (large) shape.

## Test plan

- [x] `cargo check`
- [x] `cargo clippy --all-targets`
- [x] `cargo test --all` (3 consecutive clean runs, 107 tests)
- [x] `nip33_skip_dedup_kinds_loads_from_toml` — config TOML round-trip
- [x] `nip33_skip_dedup_kinds_defaults_to_none` — absent key → `None`, bypass set is empty
- [x] `test_param_replaceable_dedup_bypass_for_skipped_kind` — drives `SqliteRepo::persist_event` through 3 sequential writes of the same `(author, kind=31113, d="token-transfer-…")` triple with the kind in the skip list, asserts all 3 events persist (instead of being collapsed to the latest)
- [ ] Post-merge: enable `nip33_skip_dedup_kinds = [31113]` in the unicity-tokens-relay deployment; verify `pg_stat_activity` shows zero `DELETE FROM event WHERE kind=31113 …` entries
- [ ] Re-evaluate whether the RDS `plan_cache_mode = force_custom_plan` band-aid can be removed (separate decision; not part of this PR)

## References

- Issue #19 — original planner cliff (root cause: generic prepared-statement plans)
- PR #20 — JOIN-shape fix (merged)
- Issue #21 — this feature
- DevOps note: `plan_cache_mode = force_custom_plan` resolved the user-visible symptom; this PR is independent and additive