### PR TITLE
feat: delivery-side observability for live broadcast path (#23)

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -21,6 +21,7 @@ These are updated synchronously as traffic hits the relay.
 | Metric | Type | Labels | Description |
 |---|---|---|---|
 | `nostr_subscriptions_active` | gauge | — | Currently-active REQ subscriptions across all clients |
+| `nostr_subscriptions_rejected_total` | counter | `reason` | REQ subscriptions rejected before registration. Reasons: `max_subscriptions` (per-connection cap of 32 hit — usually a client creating subs without CLOSEing them; this was the pattern behind the 2026-05-08 incident), `id_too_long` (sub id > 256 bytes), `scraper` (matched `is_scraper()` with `limits.limit_scrapers` enabled), `other`. |
 | `nostr_query_abort_total` | counter | `reason` | Server-side query aborts |
 
 ### Protocol commands
@@ -41,19 +42,21 @@ Counters for raw command frames received from clients.
 | `nostr_events_received_by_kind_total` | counter | `kind` | Successfully parsed events received from clients, by kind. The accounting identity `received = persisted + ephemeral_broadcast + rejected` holds across all kinds (see the three counters below). |
 | `nostr_events_persisted_by_kind_total` | counter | `kind` | Events successfully written to the database, by kind. Ephemeral events (kinds in `[20000, 30000)`) are *not* counted here — see the next row. |
 | `nostr_events_ephemeral_broadcast_by_kind_total` | counter | `kind` | Ephemeral events broadcast to subscribers without being persisted, by kind. |
+| `nostr_events_delivered_total` | counter | `kind` | Events queued for delivery to a subscriber on the realtime path, by kind. One increment per matching subscription per connection (so this is a fan-out count, not unique events). Pair with `nostr_events_persisted_by_kind_total` to see realtime delivery fan-out — a sustained drop in the ratio means broadcasts aren't reaching open subs. |
 | `nostr_events_rejected_total` | counter | `reason` | Events rejected before persistence. Reasons: `expired`, `future_dated`, `kind_blacklist`, `kind_allowlist`, `pubkey_not_whitelisted`, `not_admitted`, `insufficient_balance`, `pubkey_not_registered`, `admission_check_error`, `nip05_invalid`, `nip05_missing`, `nip05_error`, `grpc_denied`, `duplicate`, `write_error` |
 | `nostr_events_sent_total` | counter | `source` | Events sent to subscribers. `source` = `db` (historical query result) or `realtime` (broadcast match) |
 | `nostr_broadcast_lagged_total` | counter | — | Broadcast events dropped because a per-connection receiver fell behind (the receiver's slot in the broadcast channel overflowed `broadcast_buffer`). Spikes here indicate slow consumers — usually backpressure from a stuck `ws_stream.send`. |
 
 ### Latency histograms
 
-Default Prometheus buckets (`5ms` … `10s`).
+All histograms use explicit buckets reaching to 300s — Prometheus' default top bucket of 10s silently caps p99 at ~10s, which hid the 60–150s `sqlx` query latencies during the Apr 30 incident. The bucket set is `[0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300]`.
 
 | Metric | Type | Description |
 |---|---|---|
 | `nostr_query_seconds` | histogram | End-to-end subscription response time |
 | `nostr_filter_seconds` | histogram | Single SQL filter execution time |
 | `nostr_events_write_seconds` | histogram | Event-write latency |
+| `nostr_event_delivery_latency_seconds` | histogram | Wall time from db_writer broadcast send to per-subscriber WS write. Catches multi-minute live-delivery tails (the 2026-05-08 failure mode) that are invisible in persist-side latency. Observed once per successful WS write, so failed writes don't pollute the distribution. |
 
 ## State metrics (background-collected)
 

--- a/src/db.rs
+++ b/src/db.rs
@@ -35,6 +35,29 @@ pub struct SubmittedEvent {
     pub auth_pubkey: Option<Vec<u8>>,
 }
 
+/// An event being fanned out from the db writer to subscribed connections.
+///
+/// Carries the broadcast send timestamp so each subscriber can observe
+/// delivery latency (`nostr_event_delivery_latency_seconds`) from the
+/// moment the writer published the event to the moment it was actually
+/// written to that subscriber's WebSocket. Without this, a slow consumer
+/// keeping the broadcast channel saturated is invisible until users
+/// complain.
+#[derive(Clone)]
+pub struct BroadcastEvent {
+    pub event: Event,
+    pub broadcast_at: Instant,
+}
+
+impl BroadcastEvent {
+    pub fn new(event: Event) -> Self {
+        Self {
+            event,
+            broadcast_at: Instant::now(),
+        }
+    }
+}
+
 /// Database file
 pub const DB_FILE: &str = "nostr.db";
 
@@ -129,7 +152,7 @@ pub struct DbWriterContext {
     pub repo: Arc<dyn NostrRepo>,
     pub settings: Settings,
     pub event_rx: tokio::sync::mpsc::Receiver<SubmittedEvent>,
-    pub bcast_tx: tokio::sync::broadcast::Sender<Event>,
+    pub bcast_tx: tokio::sync::broadcast::Sender<BroadcastEvent>,
     pub metadata_tx: tokio::sync::broadcast::Sender<Event>,
     pub payment_tx: tokio::sync::broadcast::Sender<PaymentMessage>,
     pub shutdown: tokio::sync::broadcast::Receiver<()>,
@@ -480,7 +503,7 @@ pub async fn db_writer(ctx: DbWriterContext) -> Result<()> {
         // TODO: cache recent list of authors to remove a DB call.
         let start = Instant::now();
         if event.is_ephemeral() {
-            bcast_tx.send(event.clone()).ok();
+            bcast_tx.send(BroadcastEvent::new(event.clone())).ok();
             debug!(
                 "published ephemeral event: {:?} from: {:?} in: {:?}",
                 event.get_event_id_prefix(),
@@ -524,7 +547,7 @@ pub async fn db_writer(ctx: DbWriterContext) -> Result<()> {
                             .with_label_values(&[&event.kind.to_string()])
                             .inc();
                         // send this out to all clients
-                        bcast_tx.send(event.clone()).ok();
+                        bcast_tx.send(BroadcastEvent::new(event.clone())).ok();
                         notice_tx.try_send(Notice::saved(event.id)).ok();
                     }
                 }

--- a/src/nip05.rs
+++ b/src/nip05.rs
@@ -5,6 +5,7 @@
 //! consumes a stream of metadata events, and keeps a database table
 //! updated with the current NIP-05 verification status.
 use crate::config::VerifiedUsers;
+use crate::db::BroadcastEvent;
 use crate::error::{Error, Result};
 use crate::event::Event;
 use crate::repo::NostrRepo;
@@ -26,7 +27,7 @@ pub struct Verifier {
     /// Metadata events for us to inspect
     metadata_rx: tokio::sync::broadcast::Receiver<Event>,
     /// Newly validated events get written and then broadcast on this channel to subscribers
-    event_tx: tokio::sync::broadcast::Sender<Event>,
+    event_tx: tokio::sync::broadcast::Sender<BroadcastEvent>,
     /// Settings
     settings: crate::config::Settings,
     /// HTTP client
@@ -128,7 +129,7 @@ impl Verifier {
     pub fn new(
         repo: Arc<dyn NostrRepo>,
         metadata_rx: tokio::sync::broadcast::Receiver<Event>,
-        event_tx: tokio::sync::broadcast::Sender<Event>,
+        event_tx: tokio::sync::broadcast::Sender<BroadcastEvent>,
         settings: crate::config::Settings,
     ) -> Result<Self> {
         info!("creating NIP-05 verifier");
@@ -475,7 +476,9 @@ impl Verifier {
                             event.get_event_id_prefix(),
                             start.elapsed()
                         );
-                        self.event_tx.send(event.clone()).ok();
+                        self.event_tx
+                            .send(BroadcastEvent::new(event.clone()))
+                            .ok();
                     }
                 }
                 Err(err) => {

--- a/src/payment/mod.rs
+++ b/src/payment/mod.rs
@@ -1,5 +1,5 @@
+use crate::db::BroadcastEvent;
 use crate::error::{Error, Result};
-use crate::event::Event;
 use crate::payment::cln_rest::ClnRestPaymentProcessor;
 use crate::payment::lnbits::LNBitsPaymentProcessor;
 use crate::repo::NostrRepo;
@@ -19,7 +19,7 @@ pub struct Payment {
     /// Repository for saving/retrieving events and events
     repo: Arc<dyn NostrRepo>,
     /// Newly validated events get written and then broadcast on this channel to subscribers
-    event_tx: tokio::sync::broadcast::Sender<Event>,
+    event_tx: tokio::sync::broadcast::Sender<BroadcastEvent>,
     /// Payment message sender
     payment_tx: tokio::sync::broadcast::Sender<PaymentMessage>,
     /// Payment message receiver
@@ -99,7 +99,7 @@ impl Payment {
         repo: Arc<dyn NostrRepo>,
         payment_tx: tokio::sync::broadcast::Sender<PaymentMessage>,
         payment_rx: tokio::sync::broadcast::Receiver<PaymentMessage>,
-        event_tx: tokio::sync::broadcast::Sender<Event>,
+        event_tx: tokio::sync::broadcast::Sender<BroadcastEvent>,
         settings: crate::config::Settings,
     ) -> Result<Self> {
         info!("Create payment handler");
@@ -229,8 +229,12 @@ impl Payment {
         self.repo.write_event(&invoice_event.clone().into()).await?;
 
         // Broadcast DM events
-        self.event_tx.send(message_event.clone().into()).ok();
-        self.event_tx.send(invoice_event.clone().into()).ok();
+        self.event_tx
+            .send(BroadcastEvent::new(message_event.clone().into()))
+            .ok();
+        self.event_tx
+            .send(BroadcastEvent::new(invoice_event.clone().into()))
+            .ok();
 
         Ok(())
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -4,6 +4,7 @@ use crate::close::CloseCmd;
 use crate::config::{Settings, VerifiedUsersMode};
 use crate::conn;
 use crate::db;
+use crate::db::BroadcastEvent;
 use crate::db::SubmittedEvent;
 use crate::error::{Error, Result};
 use crate::event::Event;
@@ -71,7 +72,7 @@ async fn handle_web_request(
     repo: Arc<dyn NostrRepo>,
     settings: Settings,
     remote_addr: SocketAddr,
-    broadcast: Sender<Event>,
+    broadcast: Sender<BroadcastEvent>,
     event_tx: tokio::sync::mpsc::Sender<SubmittedEvent>,
     payment_tx: tokio::sync::broadcast::Sender<PaymentMessage>,
     shutdown: Receiver<()>,
@@ -727,7 +728,7 @@ fn create_metrics() -> (Registry, NostrMetrics) {
     .unwrap();
     let write_events = Histogram::with_opts(
         HistogramOpts::new("nostr_events_write_seconds", "Event writing response times")
-            .buckets(latency_buckets),
+            .buckets(latency_buckets.clone()),
     )
     .unwrap();
     let sent_events = IntCounterVec::new(
@@ -819,10 +820,43 @@ fn create_metrics() -> (Registry, NostrMetrics) {
         vec!["kind"].as_slice(),
     )
     .unwrap();
+    // Per-kind count of events queued for delivery to a subscriber on the
+    // realtime path (one increment per matching subscription per connection).
+    // Pairs with `nostr_events_persisted_by_kind_total` to expose delivery
+    // fan-out — a sustained drop in the ratio means broadcasts are not
+    // reaching open subs.
+    let events_delivered_by_kind = IntCounterVec::new(
+        Opts::new(
+            "nostr_events_delivered_total",
+            "Events queued for delivery to subscribers on the realtime path, by kind",
+        ),
+        vec!["kind"].as_slice(),
+    )
+    .unwrap();
+    // Per-subscriber wall time from db-writer broadcast send to WS write.
+    // Reuses the bucket set with explicit 30/60/120/300s entries so multi-
+    // minute delivery tails (the failure mode behind the 2026-05-08
+    // incident) land in a visible bucket instead of saturating at +Inf.
+    let event_delivery_latency_seconds = Histogram::with_opts(
+        HistogramOpts::new(
+            "nostr_event_delivery_latency_seconds",
+            "Wall time from broadcast send to per-subscriber WS write",
+        )
+        .buckets(latency_buckets.clone()),
+    )
+    .unwrap();
     let events_rejected = IntCounterVec::new(
         Opts::new(
             "nostr_events_rejected_total",
             "Events rejected before persistence, by reason",
+        ),
+        vec!["reason"].as_slice(),
+    )
+    .unwrap();
+    let subscriptions_rejected = IntCounterVec::new(
+        Opts::new(
+            "nostr_subscriptions_rejected_total",
+            "REQ subscriptions rejected before being registered, by reason",
         ),
         vec!["reason"].as_slice(),
     )
@@ -870,7 +904,10 @@ fn create_metrics() -> (Registry, NostrMetrics) {
     registry.register(Box::new(events_received_by_kind.clone())).unwrap();
     registry.register(Box::new(events_persisted_by_kind.clone())).unwrap();
     registry.register(Box::new(events_ephemeral_broadcast_by_kind.clone())).unwrap();
+    registry.register(Box::new(events_delivered_by_kind.clone())).unwrap();
+    registry.register(Box::new(event_delivery_latency_seconds.clone())).unwrap();
     registry.register(Box::new(events_rejected.clone())).unwrap();
+    registry.register(Box::new(subscriptions_rejected.clone())).unwrap();
     registry.register(Box::new(db_events_total.clone())).unwrap();
     registry.register(Box::new(db_events_by_kind.clone())).unwrap();
     registry.register(Box::new(db_authors_distinct.clone())).unwrap();
@@ -896,7 +933,10 @@ fn create_metrics() -> (Registry, NostrMetrics) {
         events_received_by_kind,
         events_persisted_by_kind,
         events_ephemeral_broadcast_by_kind,
+        events_delivered_by_kind,
+        event_delivery_latency_seconds,
         events_rejected,
+        subscriptions_rejected,
         db_events_total,
         db_events_by_kind,
         db_authors_distinct,
@@ -1032,7 +1072,7 @@ pub fn start_server(settings: &Settings, shutdown_rx: MpscReceiver<()>) -> Resul
         // other client on this channel.  This should be large enough
         // to accommodate slower readers (messages are dropped if
         // clients can not keep up).
-        let (bcast_tx, _) = broadcast::channel::<Event>(broadcast_buffer_limit);
+        let (bcast_tx, _) = broadcast::channel::<BroadcastEvent>(broadcast_buffer_limit);
         // validated events that need to be persisted are sent to the
         // database on via this channel.
         let (event_tx, event_rx) = mpsc::channel::<SubmittedEvent>(persist_buffer_limit);
@@ -1342,7 +1382,7 @@ async fn nostr_server(
     client_info: ClientInfo,
     settings: Settings,
     mut ws_stream: WebSocketStream<Upgraded>,
-    broadcast: Sender<Event>,
+    broadcast: Sender<BroadcastEvent>,
     event_tx: mpsc::Sender<SubmittedEvent>,
     mut shutdown: Receiver<()>,
     metrics: NostrMetrics,
@@ -1485,7 +1525,7 @@ async fn nostr_server(
                 }
             },
             bcast_result = bcast_rx.recv() => {
-                let global_event = match bcast_result {
+                let bcast_event = match bcast_result {
                     Ok(ev) => ev,
                     Err(broadcast::error::RecvError::Lagged(n)) => {
                         // Slow consumer: broadcast channel dropped n events for
@@ -1505,22 +1545,31 @@ async fn nostr_server(
                         break;
                     }
                 };
+                let global_event = &bcast_event.event;
                 let mut should_disconnect = false;
                 // an event has been broadcast to all clients
                 // first check if there is a subscription for this event.
                 for (s, sub) in conn.subscriptions() {
-                    if !sub.interested_in_event(&global_event) {
+                    if !sub.interested_in_event(global_event) {
                         continue;
                     }
                     // TODO: serialize at broadcast time, instead of
                     // once for each consumer.
-                    if let Ok(event_str) = serde_json::to_string(&global_event) {
+                    if let Ok(event_str) = serde_json::to_string(global_event) {
                         if allowed_to_send(&event_str, &conn, &settings) {
                             // create an event response and send it
                             trace!("sub match for client: {}, sub: {:?}, event: {:?}",
                                cid, s,
                                global_event.get_event_id_prefix());
                             let subesc = s.replace('"', "");
+                            let kind_str = global_event.kind.to_string();
+                            // Counted before the WS write so the per-kind delivery
+                            // total matches `sent_events{source="realtime"}` semantics
+                            // (counts attempted writes, not just successful ones).
+                            metrics
+                                .events_delivered_by_kind
+                                .with_label_values(&[&kind_str])
+                                .inc();
                             metrics.sent_events.with_label_values(&["realtime"]).inc();
                             if let Err(reason) = ws_send(&mut ws_stream, Message::Text(format!("[\"EVENT\",\"{subesc}\",{event_str}]")), ws_write_timeout).await {
                                 debug!("failed to send message (reason: {}), closing connection (cid: {})", reason, cid);
@@ -1528,6 +1577,14 @@ async fn nostr_server(
                                 should_disconnect = true;
                                 break;
                             }
+                            // Time from db-writer broadcast send to a per-subscriber
+                            // WS write. Catches the multi-minute delivery tails that
+                            // were invisible in the persist-side metrics during the
+                            // 2026-05-08 incident — observed only on success so the
+                            // histogram does not absorb ws_send failures.
+                            metrics
+                                .event_delivery_latency_seconds
+                                .observe(bcast_event.broadcast_at.elapsed().as_secs_f64());
                         }
                     } else {
                         warn!("could not serialize event: {:?}", global_event.get_event_id_prefix());
@@ -1724,6 +1781,10 @@ async fn nostr_server(
                             }
                             if settings.limits.limit_scrapers && s.is_scraper() {
                                 info!("subscription was scraper, ignoring (cid: {}, sub: {:?})", cid, s.id);
+                                metrics
+                                    .subscriptions_rejected
+                                    .with_label_values(&["scraper"])
+                                    .inc();
                                 if let Err(reason) = ws_send(&mut ws_stream, Message::Text(format!("[\"EOSE\",\"{}\"]", s.id)), ws_write_timeout).await {
                                     debug!("failed to send message (reason: {}), closing connection (cid: {})", reason, cid);
                                     metrics.disconnects.with_label_values(&[reason]).inc();
@@ -1755,6 +1816,20 @@ async fn nostr_server(
                                     }
                                 },
                                 Err(e) => {
+                                    // Distinguish max_subscriptions from id_too_long so the
+                                    // operator can tell "client is leaking subs and never
+                                    // CLOSEing them" (max_subscriptions, hot sustained rate)
+                                    // apart from "buggy client sends garbage IDs"
+                                    // (id_too_long, usually a one-off).
+                                    let reason = match e {
+                                        Error::SubMaxExceededError => "max_subscriptions",
+                                        Error::SubIdMaxLengthError => "id_too_long",
+                                        _ => "other",
+                                    };
+                                    metrics
+                                        .subscriptions_rejected
+                                        .with_label_values(&[reason])
+                                        .inc();
                                     info!("Subscription error: {} (cid: {}, sub: {:?})", e, cid, s.id);
                                     if let Err(reason) = ws_send(&mut ws_stream, make_notice_message(&Notice::message(format!("Subscription error: {e}"))), ws_write_timeout).await {
                                         debug!("failed to send notice (reason: {}), closing connection (cid: {})", reason, cid);
@@ -1896,7 +1971,10 @@ pub struct NostrMetrics {
     pub events_received_by_kind: IntCounterVec, // valid events received from clients, by kind
     pub events_persisted_by_kind: IntCounterVec, // events successfully persisted, by kind
     pub events_ephemeral_broadcast_by_kind: IntCounterVec, // ephemeral events broadcast, by kind
+    pub events_delivered_by_kind: IntCounterVec, // events queued for realtime delivery, by kind
+    pub event_delivery_latency_seconds: Histogram, // broadcast-send to per-subscriber WS write
     pub events_rejected: IntCounterVec, // events rejected before persistence, by reason
+    pub subscriptions_rejected: IntCounterVec, // REQ subscriptions rejected before registration
     pub db_events_total: IntGauge,   // estimated total events in DB
     pub db_events_by_kind: IntGaugeVec, // event count per kind in DB
     pub db_authors_distinct: IntGauge, // distinct authors in DB (estimate)

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -1,6 +1,8 @@
 use anyhow::Result;
 use futures::SinkExt;
 use futures::StreamExt;
+use hyper::body::to_bytes;
+use hyper::{Client, StatusCode, Uri};
 use std::thread;
 use std::time::Duration;
 use tokio_tungstenite::connect_async;
@@ -44,6 +46,67 @@ async fn relay_home_page() -> Result<()> {
     let relay = common::start_relay()?;
     common::wait_for_healthy_relay(&relay).await?;
     // tell relay to shutdown
+    let _res = relay.shutdown_tx.send(());
+    Ok(())
+}
+
+/// Smoke-test the delivery-side metrics introduced for issue #23. Catches
+/// the typical wiring mistakes: forgetting `registry.register(...)`,
+/// dropping a field from the `NostrMetrics` struct, or renaming a metric.
+///
+/// Two classes of metric, two assertion strategies:
+///   - Histogram / standalone Counter / Gauge: always emit even with zero
+///     samples, so plain string presence is enough.
+///   - `IntCounterVec`: prometheus only emits a series once a label has
+///     been touched. We trigger the `max_subscriptions` rejection path
+///     by saturating per-connection sub limits, then assert the resulting
+///     series appears.
+#[tokio::test]
+async fn delivery_metrics_are_registered() -> Result<()> {
+    let relay = common::start_relay()?;
+    common::wait_for_healthy_relay(&relay).await?;
+    let port = relay.port;
+
+    // Drive `nostr_subscriptions_rejected_total{reason="max_subscriptions"}`
+    // off zero so prometheus emits the series. ClientConn::max_subs is 32,
+    // so the 33rd REQ on a connection trips SubMaxExceededError.
+    let (mut ws, _res) = connect_async(format!("ws://127.0.0.1:{port}")).await?;
+    for i in 0..33 {
+        let req = format!("[\"REQ\",\"sub-{i}\",{{\"kinds\":[1]}}]");
+        ws.send(req.into()).await?;
+    }
+    // Drain a few NOTICE / EOSE responses so the relay finishes processing
+    // before we scrape; bounded so a stuck server can't hang the test.
+    for _ in 0..40 {
+        if tokio::time::timeout(Duration::from_millis(200), ws.next())
+            .await
+            .is_err()
+        {
+            break;
+        }
+    }
+
+    let uri: Uri = format!("http://127.0.0.1:{port}/metrics").parse()?;
+    let client = Client::new();
+    let res = client.get(uri).await?;
+    assert_eq!(res.status(), StatusCode::OK);
+    let body_bytes = to_bytes(res.into_body()).await?;
+    let body = std::str::from_utf8(&body_bytes)?;
+
+    for needle in [
+        "nostr_event_delivery_latency_seconds",
+        "nostr_broadcast_lagged_total",
+        "nostr_subscriptions_active",
+        // Series only exists once a label is incremented (above).
+        "nostr_subscriptions_rejected_total{reason=\"max_subscriptions\"}",
+    ] {
+        assert!(
+            body.contains(needle),
+            "expected /metrics to expose {needle}; got body:\n{body}"
+        );
+    }
+
+    ws.close(None).await.ok();
     let _res = relay.shutdown_tx.send(());
     Ok(())
 }


### PR DESCRIPTION
Closes #23.

## Summary
- Adds `nostr_events_delivered_total{kind}`, `nostr_event_delivery_latency_seconds`, and `nostr_subscriptions_rejected_total{reason}` — the delivery-side signals that were missing during the 2026-05-08 incident, where persist-side metrics were green but live delivery was lagging by minutes.
- The remaining asks in #23 are already covered: `nostr_broadcast_lagged_total` (asks 2 and 4 already exist as `nostr_broadcast_lagged_total` / `nostr_subscriptions_active`); `connections_reaped_total{reason}` is `nostr_disconnects_total{reason}`.

## Wiring
The histogram needs a "broadcast send" timestamp. The broadcast channel now carries `BroadcastEvent { event, broadcast_at: Instant }` instead of raw `Event`; the new wrapper is constructed at every `bcast_tx.send()` call site (db_writer ephemeral + persisted paths, NIP-05 verifier re-broadcast, payment DM broadcast) and consumed once per matching-subscription WS write in `nostr_server`. The histogram is observed only on successful writes so failed `ws_send` calls don't pollute the distribution.

`subscriptions_rejected_total` increments at the three rejection sites in `nostr_server`'s SubMsg handler:
- `Error::SubMaxExceededError` → `reason="max_subscriptions"` (the canonical signal for "client leaks subs and never CLOSEs them" — the pattern seen in production)
- `Error::SubIdMaxLengthError` → `reason="id_too_long"`
- `is_scraper()` + `limit_scrapers` → `reason="scraper"`

## Dashboard / docs
- Three new panels in the deployment-side `aws/nostr-relay-tokens/grafana-dashboard.json` (separate repo): "Delivery vs persist rate", "Event delivery latency (broadcast → WS write)", "Subscription rejections by reason" — all in the existing "Delivery health" row.
- `docs/metrics.md` updated with the three new metrics + a corrected note about histogram buckets (the prior "5ms … 10s" line was stale since #14).

## Test plan
- [x] `cargo test --all` — all 88 unit tests + 16 integration tests + new `delivery_metrics_are_registered` smoke test pass. The new test drives the `max_subscriptions` rejection path over a real WebSocket and verifies the resulting series appears at `/metrics`.
- [x] `cargo clippy --all-targets` — no new warnings (pre-existing only).
- [x] `cargo build --release --locked` — clean.
- [ ] Production: confirm the three new series appear in Grafana once Alloy scrapes a relay built from this branch.