### PR TITLE
UNIP-01: single-owner identity bindings

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -109,6 +109,13 @@ port = 8080
 # the future.  Recommended to reject anything greater than 30 minutes
 # from the current time, but the default is to allow any date.
 reject_future_seconds = 1800
+# Reject events that have timestamps more than this many seconds in the
+# PAST.  Complements reject_future_seconds.  Recommended as defense in
+# depth for identity bindings (UNIP-01) so a self-asserted created_at
+# cannot be set to an arbitrary past value.  Default is to allow any
+# past date.  Set generously (e.g. one day) to tolerate legitimate
+# client clock skew and delayed republishes.
+#reject_past_seconds = 86400
 
 [limits]
 # Limit events created per second, averaged over one minute.  Must be
@@ -187,6 +194,14 @@ limit_scrapers = false
 #nip42_auth = false
 # Send DMs (kind 4 and 44) and gift wraps (kind 1059) only to their authenticated recipients
 #nip42_dms = false
+# UNIP-01 single-owner namespaces.  An identity binding carrying a NIP-32
+# ["L", <namespace>] label whose value is in this list is enforced as
+# single-owner: the first author the relay records for a given identifier
+# (d-tag) owns it, ordered by relay receive time; later bindings for the
+# same identifier from a different key are rejected with `blocked:`.
+# Defaults to ["unicity:nametag"].  Set to [] to disable enforcement.
+# See docs/UNIP-01.md.
+#uniqueness_namespaces = ["unicity:nametag"]
 
 [verified_users]
 # NIP-05 verification of users.  Can be "enabled" to require NIP-05

--- a/docs/UNIP-01.md
+++ b/docs/UNIP-01.md
@@ -1,0 +1,146 @@
+# UNIP-01: Single-Owner Identity Bindings
+
+`draft` `optional`
+
+Unicity NIP — a Unicity-specific extension layered on the Nostr protocol.
+
+## Abstract
+
+UNIP-01 defines a relay-enforced ownership model for **identity-binding
+events** so that a given namespaced identifier (for example, a Unicity ID /
+nametag) maps to a single, stable owner key. Ownership is determined by relay
+receive order and is independent of self-asserted event timestamps, making
+binding resolution deterministic and robust.
+
+## Motivation
+
+Unicity publishes identity bindings as Nostr parameterized-replaceable events
+(NIP-33, kind `30078`): the `d` tag is a hash of the identifier
+(`SHA-256("unicity:nametag:" + name)`), and the content carries routing keys
+and addresses.
+
+Two properties of standard NIP-33 make resolution non-deterministic for an
+identifier that more than one key publishes a binding for:
+
+1. **Parameterized-replaceable events are scoped per author.** The replacement
+   identity is `(kind, author, d-tag)`, so bindings for the same identifier from
+   different authors coexist on the relay rather than collapsing to one. The
+   relay does not, by itself, designate which author "owns" the identifier.
+
+2. **`created_at` is self-asserted.** Each event author sets its own
+   `created_at` and signs over it. A client that selects among coexisting
+   bindings by `created_at` (lowest or highest) is ordering on a value that the
+   publisher chooses, so `created_at` is not an authoritative ownership signal
+   and cannot, on its own, guarantee a stable resolution result.
+
+UNIP-01 hardens identity resolution by giving the relay a deterministic,
+receive-time-ordered notion of ownership for marked namespaces, so a namespaced
+identifier resolves to one stable owner regardless of self-asserted timestamps.
+
+## Specification
+
+### 1. Namespace marker
+
+An identity binding that opts into UNIP-01 MUST include:
+
+- the standard parameterized-replaceable `["d", "<identifier-hash>"]` tag, and
+- a NIP-32 label tag `["L", "<namespace>"]` naming the UNIP-01 namespace
+  (e.g. `["L", "unicity:nametag"]`).
+
+Relays maintain a configurable allowlist of UNIP-01 namespaces
+(`authorization.uniqueness_namespaces`). Events that do not carry a configured
+namespace marker are handled by normal Nostr/NIP-33 rules and are unaffected by
+UNIP-01. Gating on the marker (rather than on `kind` alone) keeps shared kinds
+such as `30078` usable by unrelated applications.
+
+### 2. Ownership record
+
+For each `(namespace, d-tag)` pair, a UNIP-01 relay records:
+
+- the **owner** — the author of the first binding the relay accepts for that
+  pair, and
+- `first_seen` — the relay receive time of that first accepted binding.
+
+### 3. Acceptance rule
+
+On ingest of an event carrying a configured namespace marker, the relay accepts
+it **iff**:
+
+- no owner is recorded for `(namespace, d-tag)`, in which case the relay records
+  the event's author as owner and accepts the event; **or**
+- the recorded owner equals the event's author, in which case the relay accepts
+  the event (the owner updating its own binding, subject to ordinary NIP-33
+  replacement among that author's events).
+
+Otherwise the relay MUST reject the event and SHOULD return a NIP-20
+`["OK", <id>, false, "blocked: identifier is owned by another key"]`.
+
+The owner assignment and the acceptance check MUST be performed atomically with
+respect to concurrent writes (e.g. within the same transaction, using a unique
+constraint on `(namespace, d-tag)`), so that exactly one author is recorded as
+owner when multiple first-claims arrive concurrently.
+
+### 4. Ordering
+
+Ownership is determined solely by relay receive order (`first_seen`). The
+event's `created_at` MUST NOT influence ownership.
+
+### 5. Timestamp bounds (defense in depth)
+
+Relays SHOULD additionally bound acceptable `created_at` values (NIP-22), both
+future (`reject_future_seconds`) and past (`reject_past_seconds`), to reduce
+reliance on self-asserted timestamps. This is independent of, and complementary
+to, the ownership rule above.
+
+### 6. Resolution (client behavior)
+
+- Clients SHOULD resolve UNIP-01 namespaced identifiers only through a
+  configured set of UNIP-01 relays.
+- Clients MUST NOT order candidate bindings by `created_at`. Against a UNIP-01
+  relay, a resolved identifier yields a single owner.
+- If a client observes more than one owner for the same identifier across its
+  relay set (for example, relays in differing states of convergence), it SHOULD
+  treat the identifier as **ambiguous / unresolved** for value-bearing
+  operations rather than selecting one heuristically.
+- Clients SHOULD pin previously-resolved mappings (trust-on-first-use) and
+  surface a change in the resolved owner to the user.
+- Publishers SHOULD treat a `blocked:` rejection as a definitive
+  "identifier already owned" result.
+
+### 7. Migration / backfill
+
+When enabling UNIP-01 on a relay with existing bindings, the relay SHOULD
+backfill the ownership records by assigning each `(namespace, d-tag)` to the
+author with the minimum `first_seen` among existing matching events. Because
+`first_seen` is the relay's own receive time (not a self-asserted value), this
+preserves the earliest genuine claim the relay observed.
+
+### 8. Owner transfer (optional, future extension)
+
+An owner MAY authorize a change of the owning key by publishing a hand-off proof
+signed by the current owner key; a relay MAY honor such a proof to reassign the
+ownership record. The exact proof format is left to a future revision.
+
+## Compatibility and trust model
+
+- UNIP-01 is **additive**: events remain valid Nostr events. A relay that does
+  not implement UNIP-01 simply applies standard NIP-33 semantics; the
+  single-owner property holds only across UNIP-01 relays. Clients therefore
+  resolve through a known UNIP-01 relay set.
+- Under UNIP-01, ownership is **asserted by the relay set**. This is a federated
+  trust model: the guarantee is as strong as the agreement and integrity of the
+  relays a client trusts.
+- Deployments that require a trust-minimized authority can anchor ownership in an
+  external source (e.g. an on-chain identity registry) and treat the Nostr
+  binding as an advertisement that the client verifies against that source. That
+  is a stronger model and is out of scope for UNIP-01; UNIP-01 and such an
+  anchor compose, with the relay rule serving as a fast first-line check.
+
+## Reference implementation
+
+- Relay enforcement: `unicity-tokens-relay` — `namespace_owner` table and the
+  acceptance check in `persist_event` (`src/repo/sqlite.rs`, `src/repo/postgres.rs`),
+  configuration in `src/config.rs`, timestamp bounds in `src/event.rs`.
+- Client emission and resolution: `nostr-js-sdk` and `nostr-sdk` (Java) — the
+  `["L", "unicity:nametag"]` marker on binding events and receive-order-based
+  resolution. The two SDKs MUST remain behaviorally identical.

--- a/src/config.rs
+++ b/src/config.rs
@@ -53,6 +53,7 @@ pub struct Network {
 #[allow(unused)]
 pub struct Options {
     pub reject_future_seconds: Option<usize>, // if defined, reject any events with a timestamp more than X seconds in the future
+    pub reject_past_seconds: Option<usize>, // if defined, reject any events with a timestamp more than X seconds in the past (UNIP-01 defense in depth)
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -89,6 +90,10 @@ pub struct Authorization {
     pub pubkey_whitelist: Option<Vec<String>>, // If present, only allow these pubkeys to publish events
     pub nip42_auth: bool,                      // if true enables NIP-42 authentication
     pub nip42_dms: bool, // if true send DMs only to their authenticated recipients
+    // UNIP-01: NIP-32 label namespaces enforced as single-owner. An identity
+    // binding carrying ["L", <namespace>] in this list claims its d-tag; the
+    // first author to claim a (namespace, d-tag) owns it. See docs/UNIP-01.md.
+    pub uniqueness_namespaces: Option<Vec<String>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -356,6 +361,9 @@ impl Default for Settings {
                 pubkey_whitelist: None, // Allow any address to publish
                 nip42_auth: false,      // Disable NIP-42 authentication
                 nip42_dms: false,       // Send DMs to everybody
+                // Enforce single-owner identity bindings for the Unicity
+                // nametag namespace by default (UNIP-01).
+                uniqueness_namespaces: Some(vec!["unicity:nametag".to_owned()]),
             },
             pay_to_relay: PayToRelay {
                 enabled: false,
@@ -388,6 +396,7 @@ impl Default for Settings {
             },
             options: Options {
                 reject_future_seconds: None, // Reject events in the future if defined
+                reject_past_seconds: None,   // Reject events in the past if defined
             },
             logging: Logging {
                 folder_path: None,

--- a/src/db.rs
+++ b/src/db.rs
@@ -135,7 +135,17 @@ async fn build_postgres_pool(settings: &Settings, metrics: NostrMetrics) -> Post
     };
     metrics.db_pool_size.set(db_pool_size);
 
-    let repo = PostgresRepo::new(pool, write_pool, metrics, separate_write_pool);
+    let repo = PostgresRepo::new(
+        pool,
+        write_pool,
+        metrics,
+        separate_write_pool,
+        settings
+            .authorization
+            .uniqueness_namespaces
+            .clone()
+            .unwrap_or_default(),
+    );
 
     // Panic on migration failure
     let version = repo.migrate_up().await.unwrap();
@@ -550,6 +560,22 @@ pub async fn db_writer(ctx: DbWriterContext) -> Result<()> {
                         bcast_tx.send(BroadcastEvent::new(event.clone())).ok();
                         notice_tx.try_send(Notice::saved(event.id)).ok();
                     }
+                }
+                // UNIP-01: the event claims a single-owner identifier already
+                // held by a different key — reject with a NIP-20 `blocked:`.
+                Err(Error::EventBlocked(reason)) => {
+                    debug!(
+                        "blocked event: {:?} (kind: {}) from: {:?} — {}",
+                        event.get_event_id_prefix(),
+                        event.kind,
+                        event.get_author_prefix(),
+                        reason,
+                    );
+                    notice_tx.try_send(Notice::blocked(event.id, &reason)).ok();
+                    metrics
+                        .events_rejected
+                        .with_label_values(&["blocked_uniqueness"])
+                        .inc();
                 }
                 Err(err) => {
                     warn!("event insert failed: {:?}", err);

--- a/src/error.rs
+++ b/src/error.rs
@@ -84,6 +84,11 @@ pub enum Error {
     HTTPError(http::Error),
     #[error("Unknown/Undocumented")]
     UnknownError,
+    // UNIP-01: the event claims a single-owner namespaced identifier that is
+    // already owned by a different key. Surfaced to the client as a NIP-20
+    // `blocked:` result.
+    #[error("Event blocked: {0}")]
+    EventBlocked(String),
 }
 
 //impl From<Box<dyn std::error::Error>> for Error {

--- a/src/event.rs
+++ b/src/event.rs
@@ -338,8 +338,11 @@ impl Event {
         if let Some(allowable_past) = reject_past_seconds {
             // reject events whose timestamp is implausibly far in the past;
             // complements the future bound (UNIP-01 defense in depth so a
-            // self-asserted created_at cannot be set to an arbitrary past value)
-            if self.created_at + (allowable_past as u64) < curr_time {
+            // self-asserted created_at cannot be set to an arbitrary past value).
+            // Subtract rather than add so a near-u64::MAX created_at cannot
+            // overflow; a future timestamp (created_at >= curr_time) is never
+            // "too far past" and is handled by the future bound above.
+            if self.created_at < curr_time && curr_time - self.created_at > allowable_past as u64 {
                 let delta = curr_time - self.created_at;
                 debug!(
                     "event is too far in the past ({} seconds), rejecting",
@@ -922,5 +925,16 @@ mod tests {
         let mut event = Event::simple_event();
         event.created_at = crate::utils::unix_time();
         assert!(event.is_valid_timestamp(Some(1800), Some(86400)));
+    }
+
+    #[test]
+    fn timestamp_past_bound_no_overflow_on_max_created_at() {
+        let mut event = Event::simple_event();
+        event.created_at = u64::MAX;
+        // Past bound only: must not overflow/panic. A far-future timestamp is
+        // not "too far past", so the past bound does not reject it.
+        assert!(event.is_valid_timestamp(None, Some(86400)));
+        // With a future bound configured, the far-future timestamp is rejected.
+        assert!(!event.is_valid_timestamp(Some(1800), Some(86400)));
     }
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -318,9 +318,13 @@ impl Event {
     }
 
     #[must_use]
-    pub fn is_valid_timestamp(&self, reject_future_seconds: Option<usize>) -> bool {
+    pub fn is_valid_timestamp(
+        &self,
+        reject_future_seconds: Option<usize>,
+        reject_past_seconds: Option<usize>,
+    ) -> bool {
+        let curr_time = unix_time();
         if let Some(allowable_future) = reject_future_seconds {
-            let curr_time = unix_time();
             // calculate difference, plus how far future we allow
             if curr_time + (allowable_future as u64) < self.created_at {
                 let delta = self.created_at - curr_time;
@@ -331,7 +335,36 @@ impl Event {
                 return false;
             }
         }
+        if let Some(allowable_past) = reject_past_seconds {
+            // reject events whose timestamp is implausibly far in the past;
+            // complements the future bound (UNIP-01 defense in depth so a
+            // self-asserted created_at cannot be set to an arbitrary past value)
+            if self.created_at + (allowable_past as u64) < curr_time {
+                let delta = curr_time - self.created_at;
+                debug!(
+                    "event is too far in the past ({} seconds), rejecting",
+                    delta
+                );
+                return false;
+            }
+        }
         true
+    }
+
+    /// UNIP-01: if this event opts into one of the configured single-owner
+    /// namespaces, return `(namespace, d_tag)`. The event must carry a NIP-32
+    /// `["L", <namespace>]` label whose value is one of `namespaces`, together
+    /// with a parameterized-replaceable `d` tag. Returns `None` otherwise.
+    #[must_use]
+    pub fn uniqueness_claim(&self, namespaces: &[String]) -> Option<(String, String)> {
+        if namespaces.is_empty() {
+            return None;
+        }
+        let d_tag = self.distinct_param()?;
+        self.tag_values_by_name("L")
+            .into_iter()
+            .find(|label| namespaces.iter().any(|ns| ns == label))
+            .map(|ns| (ns, d_tag))
     }
 
     /// Check if this event has a valid signature.
@@ -794,5 +827,100 @@ mod tests {
             vec!["expiration".to_string(), (20).to_string()],
         ];
         assert_eq!(event.expiration(), Some(10));
+    }
+
+    // ---- UNIP-01: uniqueness_claim ----
+
+    #[test]
+    fn uniqueness_claim_matches_marker() {
+        let mut event = Event::simple_event();
+        event.kind = 30078;
+        event.tags = vec![
+            vec!["d".to_owned(), "abc".to_owned()],
+            vec!["L".to_owned(), "unicity:nametag".to_owned()],
+        ];
+        let ns = vec!["unicity:nametag".to_owned()];
+        assert_eq!(
+            event.uniqueness_claim(&ns),
+            Some(("unicity:nametag".to_owned(), "abc".to_owned()))
+        );
+    }
+
+    #[test]
+    fn uniqueness_claim_requires_marker() {
+        let mut event = Event::simple_event();
+        event.kind = 30078;
+        event.tags = vec![vec!["d".to_owned(), "abc".to_owned()]];
+        let ns = vec!["unicity:nametag".to_owned()];
+        assert_eq!(event.uniqueness_claim(&ns), None);
+    }
+
+    #[test]
+    fn uniqueness_claim_ignores_unconfigured_namespace() {
+        let mut event = Event::simple_event();
+        event.kind = 30078;
+        event.tags = vec![
+            vec!["d".to_owned(), "abc".to_owned()],
+            vec!["L".to_owned(), "other:ns".to_owned()],
+        ];
+        let ns = vec!["unicity:nametag".to_owned()];
+        assert_eq!(event.uniqueness_claim(&ns), None);
+    }
+
+    #[test]
+    fn uniqueness_claim_requires_param_replaceable_kind() {
+        // kind 1 is not parameterized-replaceable, so there is no d-tag claim
+        let mut event = Event::simple_event();
+        event.kind = 1;
+        event.tags = vec![
+            vec!["d".to_owned(), "abc".to_owned()],
+            vec!["L".to_owned(), "unicity:nametag".to_owned()],
+        ];
+        let ns = vec!["unicity:nametag".to_owned()];
+        assert_eq!(event.uniqueness_claim(&ns), None);
+    }
+
+    #[test]
+    fn uniqueness_claim_empty_config_disables() {
+        let mut event = Event::simple_event();
+        event.kind = 30078;
+        event.tags = vec![
+            vec!["d".to_owned(), "abc".to_owned()],
+            vec!["L".to_owned(), "unicity:nametag".to_owned()],
+        ];
+        assert_eq!(event.uniqueness_claim(&[]), None);
+    }
+
+    // ---- UNIP-01: is_valid_timestamp past/future bounds ----
+
+    #[test]
+    fn timestamp_past_bound_rejects_backdated() {
+        let mut event = Event::simple_event();
+        event.created_at = 1000; // far in the past
+        // future bound only -> accepted
+        assert!(event.is_valid_timestamp(Some(1800), None));
+        // past bound active -> rejected
+        assert!(!event.is_valid_timestamp(Some(1800), Some(86400)));
+    }
+
+    #[test]
+    fn timestamp_future_bound_rejects_postdated() {
+        let mut event = Event::simple_event();
+        event.created_at = 9_999_999_999; // year 2286
+        assert!(!event.is_valid_timestamp(Some(1800), None));
+    }
+
+    #[test]
+    fn timestamp_no_bounds_accepts_any() {
+        let mut event = Event::simple_event();
+        event.created_at = 0;
+        assert!(event.is_valid_timestamp(None, None));
+    }
+
+    #[test]
+    fn timestamp_recent_accepted_within_bounds() {
+        let mut event = Event::simple_event();
+        event.created_at = crate::utils::unix_time();
+        assert!(event.is_valid_timestamp(Some(1800), Some(86400)));
     }
 }

--- a/src/repo/postgres.rs
+++ b/src/repo/postgres.rs
@@ -35,6 +35,9 @@ pub struct PostgresRepo {
     /// — pool metrics must read from one of them only, otherwise the
     /// in-use count would double-count the shared pool.
     separate_write_pool: bool,
+    /// UNIP-01 single-owner namespaces (NIP-32 label values enforced as
+    /// single-owner identity bindings). Empty disables enforcement.
+    uniqueness_namespaces: Vec<String>,
 }
 
 impl PostgresRepo {
@@ -43,12 +46,14 @@ impl PostgresRepo {
         cw: PostgresPool,
         m: NostrMetrics,
         separate_write_pool: bool,
+        uniqueness_namespaces: Vec<String>,
     ) -> PostgresRepo {
         PostgresRepo {
             conn: c,
             conn_write: cw,
             metrics: m,
             separate_write_pool,
+            uniqueness_namespaces,
         }
     }
 
@@ -136,6 +141,36 @@ impl NostrRepo for PostgresRepo {
         let delegator_blob: Option<Vec<u8>> =
             e.delegated_by.as_ref().and_then(|d| hex::decode(d).ok());
         let event_str = serde_json::to_string(&e).unwrap();
+
+        // UNIP-01: single-owner enforcement. If this event claims a configured
+        // single-owner namespace (NIP-32 ["L", ns] + d-tag), the first author
+        // the relay records owns the (namespace, d-tag); a later event from a
+        // different author is rejected. Ownership is by relay receive time
+        // (namespace_owner.first_seen DEFAULT now()), never the event's
+        // self-asserted created_at. The upsert + re-select run in this
+        // transaction so concurrent first-claims serialize on the primary key.
+        if let Some((namespace, d_tag)) = e.uniqueness_claim(&self.uniqueness_namespaces) {
+            sqlx::query(
+                "INSERT INTO namespace_owner (namespace, d_tag, author) VALUES ($1, $2, $3) ON CONFLICT (namespace, d_tag) DO NOTHING;")
+                .bind(&namespace)
+                .bind(&d_tag)
+                .bind(&pubkey_blob)
+                .execute(&mut tx)
+                .await?;
+            let owner: Vec<u8> = sqlx::query_scalar(
+                "SELECT author FROM namespace_owner WHERE namespace=$1 AND d_tag=$2;")
+                .bind(&namespace)
+                .bind(&d_tag)
+                .fetch_one(&mut tx)
+                .await?;
+            if Some(&owner) != pubkey_blob.as_ref() {
+                // Returning here drops `tx`, rolling back the no-op upsert and
+                // leaving the existing owner record intact.
+                return Err(error::Error::EventBlocked(
+                    "nametag is owned by another key".to_owned(),
+                ));
+            }
+        }
 
         // determine if this event would be shadowed by an existing
         // replaceable event or parameterized replaceable event.

--- a/src/repo/postgres_migration.rs
+++ b/src/repo/postgres_migration.rs
@@ -39,6 +39,7 @@ pub async fn run_migrations(db: &PostgresPool) -> crate::error::Result<usize> {
     run_migration(m005::migration(), db).await;
     m006::run(db).await?;
     m007::run(db).await?;
+    run_migration(m008::migration(), db).await;
     Ok(current_version(db).await as usize)
 }
 
@@ -576,5 +577,48 @@ mod m007 {
 
         info!("m007: complete");
         Ok(())
+    }
+}
+
+mod m008 {
+    use crate::repo::postgres_migration::{Migration, SimpleSqlMigration};
+
+    pub const VERSION: i64 = 8;
+
+    pub fn migration() -> impl Migration {
+        SimpleSqlMigration {
+            serial_number: VERSION,
+            sql: vec![
+                // UNIP-01 single-owner identity bindings (see docs/UNIP-01.md).
+                r#"
+CREATE TABLE IF NOT EXISTS namespace_owner (
+	namespace text NOT NULL,
+	d_tag text NOT NULL,
+	author bytea NOT NULL,
+	first_seen timestamp with time zone NOT NULL DEFAULT now(),
+	CONSTRAINT namespace_owner_pkey PRIMARY KEY (namespace, d_tag)
+);
+                "#,
+                // Backfill existing Unicity nametag bindings: assign each d-tag
+                // to the author the relay saw FIRST (by first_seen), i.e. relay
+                // receive time — never the events' self-asserted created_at.
+                // Legacy bindings are identified by their content marker
+                // ("nametag_hash"); d_tag is reconstructed to the same
+                // lowercase-hex string that distinct_param() produces at runtime.
+                r#"
+INSERT INTO namespace_owner (namespace, d_tag, author, first_seen)
+SELECT 'unicity:nametag',
+       COALESCE(encode(dt.value_hex, 'hex'), convert_from(dt.value, 'UTF8')),
+       (ARRAY_AGG(e.pub_key ORDER BY e.first_seen ASC))[1],
+       MIN(e.first_seen)
+FROM event e
+JOIN tag dt ON dt.event_id = e.id AND dt.name = 'd'
+WHERE e.kind = 30078
+  AND position('nametag_hash' in convert_from(e.content, 'UTF8')) > 0
+GROUP BY 1, 2
+ON CONFLICT (namespace, d_tag) DO NOTHING;
+                "#,
+            ],
+        }
     }
 }

--- a/src/repo/sqlite.rs
+++ b/src/repo/sqlite.rs
@@ -51,6 +51,9 @@ pub struct SqliteRepo {
     write_in_progress: Arc<Mutex<u64>>,
     /// Semaphore for readers to acquire blocking threads
     reader_threads_ready: Arc<Semaphore>,
+    /// UNIP-01 single-owner namespaces (NIP-32 label values enforced as
+    /// single-owner identity bindings). Empty disables enforcement.
+    uniqueness_namespaces: Vec<String>,
 }
 
 impl SqliteRepo {
@@ -99,6 +102,11 @@ impl SqliteRepo {
             checkpoint_in_progress,
             write_in_progress,
             reader_threads_ready,
+            uniqueness_namespaces: settings
+                .authorization
+                .uniqueness_namespaces
+                .clone()
+                .unwrap_or_default(),
         }
     }
 
@@ -129,7 +137,11 @@ impl SqliteRepo {
     }
 
     /// Persist an event to the database, returning rows added.
-    pub fn persist_event(conn: &mut PooledConnection, e: &Event) -> Result<u64> {
+    pub fn persist_event(
+        conn: &mut PooledConnection,
+        e: &Event,
+        uniqueness_namespaces: &[String],
+    ) -> Result<u64> {
         // enable auto vacuum
         conn.execute_batch("pragma auto_vacuum = FULL")?;
 
@@ -141,6 +153,31 @@ impl SqliteRepo {
         let delegator_blob: Option<Vec<u8>> =
             e.delegated_by.as_ref().and_then(|d| hex::decode(d).ok());
         let event_str = serde_json::to_string(&e).ok();
+        // UNIP-01: single-owner enforcement. If this event claims a configured
+        // single-owner namespace (NIP-32 ["L", ns] + d-tag), the first author
+        // the relay records owns the (namespace, d-tag); a later event from a
+        // different author is rejected. Ownership is by relay receive time
+        // (first_seen), never the event's self-asserted created_at. The
+        // INSERT-OR-IGNORE + re-SELECT runs in this transaction so concurrent
+        // first-claims serialize on the primary key.
+        if let Some((namespace, d_tag)) = e.uniqueness_claim(uniqueness_namespaces) {
+            tx.execute(
+                "INSERT OR IGNORE INTO namespace_owner (namespace, d_tag, author, first_seen) VALUES (?1, ?2, ?3, strftime('%s','now'));",
+                params![namespace, d_tag, pubkey_blob],
+            )?;
+            let owner: Vec<u8> = tx.query_row(
+                "SELECT author FROM namespace_owner WHERE namespace=?1 AND d_tag=?2;",
+                params![namespace, d_tag],
+                |row| row.get(0),
+            )?;
+            if Some(&owner) != pubkey_blob.as_ref() {
+                // Dropping `tx` here rolls back (incl. the no-op INSERT OR
+                // IGNORE above), leaving the existing owner record intact.
+                return Err(crate::error::Error::EventBlocked(
+                    "nametag is owned by another key".to_owned(),
+                ));
+            }
+        }
         // check for replaceable events that would hide this one; we won't even attempt to insert these.
         if e.is_replaceable() {
             let repl_count = tx.query_row(
@@ -313,13 +350,14 @@ impl NostrRepo for SqliteRepo {
         //let mut conn = self.write_pool.get()?;
         let pool = self.write_pool.clone();
         let e = e.clone();
+        let uniqueness_namespaces = self.uniqueness_namespaces.clone();
         let event_count = task::spawn_blocking(move || {
             let mut conn = pool.get()?;
             // this could fail because the database was busy; try
             // multiple times before giving up.
             loop {
                 attempts += 1;
-                let wr = SqliteRepo::persist_event(&mut conn, &e);
+                let wr = SqliteRepo::persist_event(&mut conn, &e, &uniqueness_namespaces);
                 match wr {
                     Err(SqlError(rusqlite::Error::SqliteFailure(e, _))) => {
                         // this basically means that NIP-05 or another
@@ -1818,5 +1856,102 @@ mod tests {
             .map(|r| r.unwrap())
             .collect();
         assert_eq!(remaining, vec![3]);
+    }
+
+    /// UNIP-01: a single-owner namespace binding (NIP-32 ["L","unicity:nametag"]
+    /// + d-tag) is owned by the first author the relay accepts; a later binding
+    /// for the same identifier from a different author is rejected, while the
+    /// owner can keep updating its own binding.
+    #[test]
+    fn unip01_persist_event_enforces_single_owner() {
+        let manager = SqliteConnectionManager::memory();
+        let pool = r2d2::Pool::builder().max_size(1).build(manager).unwrap();
+        let mut conn = pool.get().unwrap();
+        upgrade_db(&mut conn).unwrap();
+
+        let ns = vec!["unicity:nametag".to_owned()];
+        let author_a = "aa".repeat(32);
+        let author_b = "bb".repeat(32);
+
+        let mk = |id: &str, author: &str, created_at: u64| Event {
+            id: id.to_owned(),
+            pubkey: author.to_owned(),
+            delegated_by: None,
+            created_at,
+            kind: 30078,
+            tags: vec![
+                vec!["d".to_owned(), "nm1".to_owned()],
+                vec!["L".to_owned(), "unicity:nametag".to_owned()],
+            ],
+            content: "{\"nametag_hash\":\"x\"}".to_owned(),
+            sig: "00".to_owned(),
+            tagidx: None,
+        };
+
+        // First author claims the identifier.
+        let a1 = mk(&"11".repeat(32), &author_a, 1_700_000_000);
+        assert_eq!(
+            SqliteRepo::persist_event(&mut conn, &a1, &ns).unwrap(),
+            1,
+            "first author should be accepted"
+        );
+
+        // A different author claiming the same identifier is rejected.
+        let b1 = mk(&"22".repeat(32), &author_b, 1_700_000_000);
+        assert!(
+            matches!(
+                SqliteRepo::persist_event(&mut conn, &b1, &ns),
+                Err(crate::error::Error::EventBlocked(_))
+            ),
+            "a different author must be blocked"
+        );
+
+        // The original owner can still update its own binding.
+        let a2 = mk(&"33".repeat(32), &author_a, 1_700_000_001);
+        assert_eq!(
+            SqliteRepo::persist_event(&mut conn, &a2, &ns).unwrap(),
+            1,
+            "owner should be able to update"
+        );
+
+        // Ownership is recorded as the first author, by relay receive order.
+        let owner: Vec<u8> = conn
+            .query_row(
+                "SELECT author FROM namespace_owner WHERE namespace='unicity:nametag' AND d_tag='nm1';",
+                [],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(owner, hex::decode(&author_a).unwrap());
+    }
+
+    /// Without the namespace marker, the same identifier from two authors is
+    /// NOT subject to single-owner enforcement (ordinary NIP-33 per-author
+    /// semantics) — enforcement is opt-in via the ["L", ...] label.
+    #[test]
+    fn unip01_no_marker_is_not_enforced() {
+        let manager = SqliteConnectionManager::memory();
+        let pool = r2d2::Pool::builder().max_size(1).build(manager).unwrap();
+        let mut conn = pool.get().unwrap();
+        upgrade_db(&mut conn).unwrap();
+
+        let ns = vec!["unicity:nametag".to_owned()];
+        let mk = |id: &str, author: &str| Event {
+            id: id.to_owned(),
+            pubkey: author.to_owned(),
+            delegated_by: None,
+            created_at: 1_700_000_000,
+            kind: 30078,
+            tags: vec![vec!["d".to_owned(), "nm2".to_owned()]], // no ["L", ...]
+            content: "{\"nametag_hash\":\"x\"}".to_owned(),
+            sig: "00".to_owned(),
+            tagidx: None,
+        };
+
+        let a = mk(&"44".repeat(32), &"aa".repeat(32));
+        let b = mk(&"55".repeat(32), &"bb".repeat(32));
+        assert_eq!(SqliteRepo::persist_event(&mut conn, &a, &ns).unwrap(), 1);
+        // unmarked binding from a different author is stored (not blocked)
+        assert_eq!(SqliteRepo::persist_event(&mut conn, &b, &ns).unwrap(), 1);
     }
 }

--- a/src/repo/sqlite_migration.rs
+++ b/src/repo/sqlite_migration.rs
@@ -23,7 +23,7 @@ pragma mmap_size = 0; -- disable mmap (default)
 "##;
 
 /// Latest database version
-pub const DB_VERSION: usize = 18;
+pub const DB_VERSION: usize = 19;
 
 /// Schema definition
 const INIT_SQL: &str = formatcp!(
@@ -123,6 +123,16 @@ CONSTRAINT invoice_pubkey_fkey FOREIGN KEY (pubkey) REFERENCES account (pubkey) 
 
 -- Create invoice index
 CREATE INDEX IF NOT EXISTS invoice_pubkey_index ON invoice(pubkey);
+
+-- UNIP-01 single-owner identity bindings (see docs/UNIP-01.md).
+-- Records the owning author of each (namespace, d-tag), by relay receive time.
+CREATE TABLE IF NOT EXISTS namespace_owner (
+namespace TEXT NOT NULL, -- UNIP-01 namespace, e.g. "unicity:nametag"
+d_tag TEXT NOT NULL,     -- the parameterized-replaceable d-tag value
+author BLOB NOT NULL,    -- pubkey of the first author seen for this (namespace, d-tag)
+first_seen INTEGER NOT NULL, -- relay receive time of the first accepted binding
+PRIMARY KEY (namespace, d_tag)
+);
 
 
 "##,
@@ -244,6 +254,9 @@ pub fn upgrade_db(conn: &mut PooledConnection) -> Result<usize> {
             }
             if curr_version == 17 {
                 curr_version = mig_17_to_18(conn)?;
+            }
+            if curr_version == 18 {
+                curr_version = mig_18_to_19(conn)?;
             }
 
             if curr_version == DB_VERSION {
@@ -838,4 +851,45 @@ PRAGMA user_version = 18;
         }
     }
     Ok(18)
+}
+
+fn mig_18_to_19(conn: &mut PooledConnection) -> Result<usize> {
+    info!("database schema needs update from 18->19");
+    // UNIP-01: introduce the single-owner ownership table and backfill it from
+    // existing Unicity nametag bindings. Ownership is assigned to the author the
+    // relay saw FIRST (MIN(first_seen)), i.e. by relay receive time — never by
+    // the events' self-asserted created_at. Legacy bindings are identified by
+    // their content marker ("nametag_hash"), since the multi-char "nametag" tag
+    // is not stored in the (single-char) tag index. See docs/UNIP-01.md.
+    let upgrade_sql = r##"
+CREATE TABLE IF NOT EXISTS namespace_owner (
+namespace TEXT NOT NULL,
+d_tag TEXT NOT NULL,
+author BLOB NOT NULL,
+first_seen INTEGER NOT NULL,
+PRIMARY KEY (namespace, d_tag)
+);
+
+INSERT OR IGNORE INTO namespace_owner (namespace, d_tag, author, first_seen)
+SELECT 'unicity:nametag', dt.value, e.author, MIN(e.first_seen)
+FROM event e
+JOIN tag dt ON dt.event_id = e.id AND dt.name = 'd'
+WHERE e.kind = 30078
+  AND e.content LIKE '%nametag_hash%'
+  AND dt.value IS NOT NULL
+GROUP BY dt.value;
+
+pragma optimize;
+PRAGMA user_version = 19;
+"##;
+    match conn.execute_batch(upgrade_sql) {
+        Ok(()) => {
+            info!("database schema upgraded v18 -> v19");
+        }
+        Err(err) => {
+            error!("update (v18->v19) failed: {}", err);
+            panic!("database could not be upgraded");
+        }
+    }
+    Ok(19)
 }

--- a/src/repo/sqlite_migration.rs
+++ b/src/repo/sqlite_migration.rs
@@ -871,13 +871,13 @@ PRIMARY KEY (namespace, d_tag)
 );
 
 INSERT OR IGNORE INTO namespace_owner (namespace, d_tag, author, first_seen)
-SELECT 'unicity:nametag', dt.value, e.author, MIN(e.first_seen)
+SELECT 'unicity:nametag', COALESCE(lower(hex(dt.value_hex)), dt.value), e.author, MIN(e.first_seen)
 FROM event e
 JOIN tag dt ON dt.event_id = e.id AND dt.name = 'd'
 WHERE e.kind = 30078
   AND e.content LIKE '%nametag_hash%'
-  AND dt.value IS NOT NULL
-GROUP BY dt.value;
+  AND (dt.value IS NOT NULL OR dt.value_hex IS NOT NULL)
+GROUP BY COALESCE(lower(hex(dt.value_hex)), dt.value);
 
 pragma optimize;
 PRAGMA user_version = 19;

--- a/src/server.rs
+++ b/src/server.rs
@@ -1680,8 +1680,11 @@ async fn nostr_server(
                                         metrics.disconnects.with_label_values(&[reason]).inc();
                                         break;
                                     }
-                                    // check if the event is too far in the future.
-                                } else if e.is_valid_timestamp(settings.options.reject_future_seconds) {
+                                    // check if the event created_at is within the acceptable range.
+                                } else if e.is_valid_timestamp(
+                                    settings.options.reject_future_seconds,
+                                    settings.options.reject_past_seconds,
+                                ) {
                                     // Write this to the database.
                                     let auth_pubkey = conn.auth_pubkey().and_then(|pubkey| hex::decode(pubkey).ok());
                                     let submit_event = SubmittedEvent {
@@ -1694,17 +1697,21 @@ async fn nostr_server(
                                     event_tx.send(submit_event).await.ok();
                                     client_published_event_count += 1;
                                 } else {
-                                    metrics.events_rejected.with_label_values(&["future_dated"]).inc();
-                                    info!("client: {} sent a far future-dated event", cid);
-                                    if let Some(fut_sec) = settings.options.reject_future_seconds {
-                                        let msg = format!("The event created_at field is out of the acceptable range (+{fut_sec}sec) for this relay.");
-                                        let notice = Notice::invalid(e.id, &msg);
-                                        if let Err(reason) = ws_send(&mut ws_stream, make_notice_message(&notice), ws_write_timeout).await {
-                                            debug!("failed to send notice (reason: {}), closing connection (cid: {})", reason, cid);
-                                            metrics.disconnects.with_label_values(&[reason]).inc();
-                                            break;
-
-                                        }
+                                    metrics.events_rejected.with_label_values(&["out_of_range_created_at"]).inc();
+                                    info!("client: {} sent an out-of-range created_at event", cid);
+                                    let fut = settings.options.reject_future_seconds;
+                                    let past = settings.options.reject_past_seconds;
+                                    let msg = match (fut, past) {
+                                        (Some(f), Some(p)) => format!("The event created_at field is out of the acceptable range (-{p}sec to +{f}sec) for this relay."),
+                                        (Some(f), None) => format!("The event created_at field is out of the acceptable range (+{f}sec) for this relay."),
+                                        (None, Some(p)) => format!("The event created_at field is out of the acceptable range (-{p}sec) for this relay."),
+                                        (None, None) => "The event created_at field is out of the acceptable range for this relay.".to_string(),
+                                    };
+                                    let notice = Notice::invalid(e.id, &msg);
+                                    if let Err(reason) = ws_send(&mut ws_stream, make_notice_message(&notice), ws_write_timeout).await {
+                                        debug!("failed to send notice (reason: {}), closing connection (cid: {})", reason, cid);
+                                        metrics.disconnects.with_label_values(&[reason]).inc();
+                                        break;
                                     }
                                 }
                             },


### PR DESCRIPTION
## Summary

Introduces **UNIP-01**, a relay-enforced single-owner model for namespaced identity bindings (e.g. Unicity nametags). A namespaced identifier resolves to one stable owner determined by **relay receive order**, rather than by the self-asserted `created_at` on events. This hardens identity-binding resolution and makes it deterministic.

Spec: `docs/UNIP-01.md`.

## Why

Nametag bindings are NIP-33 parameterized-replaceable events (kind 30078, `d` = hash of the name). Under standard NIP-33:
- bindings are scoped per author, so bindings for the same identifier from different keys coexist and the relay designates no owner; and
- selecting among them by `created_at` is not robust, because `created_at` is set and signed by each event's own author.

UNIP-01 gives the relay a deterministic, receive-time-ordered notion of ownership for opted-in namespaces.

## What changed

- **Spec**: `docs/UNIP-01.md`.
- **Config**: `options.reject_past_seconds` (NIP-22 lower bound on `created_at`, opt-in) and `authorization.uniqueness_namespaces` (default `["unicity:nametag"]`).
- **Event**: `is_valid_timestamp` gains a past bound; `uniqueness_claim()` detects the NIP-32 `["L", <namespace>]` marker + `d` tag.
- **Enforcement** (sqlite + postgres): within the write transaction, the first author to claim a `(namespace, d-tag)` is recorded as owner (by relay receive time); a later binding for the same identifier from a different key is rejected with a NIP-20 `blocked:` result. The owner can keep updating its own binding (ordinary NIP-33 replacement).
- **Schema + backfill**: new `namespace_owner` table (sqlite migration 18→19, postgres `m008`), backfilled from existing bindings by `MIN(first_seen)` so current owners are preserved by real receive order.
- Enforcement is **opt-in via the marker** and gated on the configured namespace list, so shared kinds (e.g. NIP-78 kind 30078) used by unrelated apps are unaffected.

## Trust model

Ownership is asserted by the UNIP-01 relay set (federated trust). A trust-minimized authority (e.g. an on-chain registry) can layer on top with the binding verified by the client; that is out of scope here and composes with this change.

## Testing

- `cargo test --lib`: 99/99 pass, including new unit tests (marker detection + timestamp bounds) and DB-level tests verifying a second author is rejected while the owner can update.
- Postgres mirrors the verified sqlite logic; runtime Postgres tests run in CI.

## Follow-up (separate PRs)

Client-side changes in `nostr-js-sdk` and `nostr-sdk` (Java), kept behaviorally identical: emit the `["L","unicity:nametag"]` marker on bindings, treat `blocked:` as a hard publish failure, and prefer marker-carrying bindings at resolution (with legacy fallback during migration).